### PR TITLE
chore: stage 1 repo hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ build/
 # Editor/IDE
 # .idea/
 # .vscode/
+*.~undo-tree~

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Project Overview
 
 Go MCP server for Todoist. Communicates via stdio (stdout = MCP protocol, stderr = logs).
-Built with [go-sdk v1.4.0](https://github.com/modelcontextprotocol/go-sdk).
+Built with [go-sdk v1.6.1](https://github.com/modelcontextprotocol/go-sdk).
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A Model Context Protocol (MCP) server for Todoist, written in Go. This server enables Claude and other MCP clients to interact with your Todoist tasks, projects, sections, labels, and comments using natural language. Includes GTD workflow tools for inbox processing and weekly reviews.
 
-This is a Go rewrite of the original [TypeScript implementation](https://github.com/abhiz123/todoist-mcp-server), built with the official [go-sdk v1.4.0](https://github.com/modelcontextprotocol/go-sdk).
+This is a Go rewrite of the original [TypeScript implementation](https://github.com/abhiz123/todoist-mcp-server), built with the official [go-sdk v1.6.1](https://github.com/modelcontextprotocol/go-sdk).
 
 ## Features
 
@@ -273,7 +273,7 @@ MIT License - see [LICENSE](LICENSE) file for details.
 ## Acknowledgments
 
 - Original TypeScript implementation by [abhiz123](https://github.com/abhiz123/todoist-mcp-server)
-- Built with [go-sdk v1.4.0](https://github.com/modelcontextprotocol/go-sdk)
+- Built with [go-sdk v1.6.1](https://github.com/modelcontextprotocol/go-sdk)
 - GitHub Actions and Makefile structure inspired by [mcp-obsidian](https://github.com/nsega/mcp-obsidian)
 
 ## Contributing


### PR DESCRIPTION
Stage 1 of the tech debt refactor (see docs/superpowers/specs/2026-07-14-tech-debt-refactor-design.md). Removes the stray 11MB binary and editor artifact from the working tree, adds the ignore pattern, and syncs go-sdk version references to v1.6.1. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015j22Jr9L3mzY3wNohfvWcu