### PR TITLE
refactor: stage 2 client API reshape (context + typed requests)

### DIFF
--- a/internal/todoist/client.go
+++ b/internal/todoist/client.go
@@ -1,6 +1,7 @@
 package todoist
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -52,7 +53,7 @@ func NewClient(token string, opts ...Option) *Client {
 
 // do executes an HTTP request against the Todoist API and returns the
 // response body bytes. For responses with no content (204) it returns nil.
-func (c *Client) do(method, endpoint string, body any) ([]byte, error) {
+func (c *Client) do(ctx context.Context, method, endpoint string, body any) ([]byte, error) {
 	var reqBody io.Reader
 	if body != nil {
 		data, err := json.Marshal(body)
@@ -62,7 +63,7 @@ func (c *Client) do(method, endpoint string, body any) ([]byte, error) {
 		reqBody = strings.NewReader(string(data))
 	}
 
-	req, err := http.NewRequest(method, c.baseURL+endpoint, reqBody)
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+endpoint, reqBody)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}

--- a/internal/todoist/client.go
+++ b/internal/todoist/client.go
@@ -38,9 +38,6 @@ func WithBaseURL(url string) Option {
 	return func(cl *Client) { cl.baseURL = url }
 }
 
-// Ptr returns a pointer to v. Convenience for building request structs.
-func Ptr[T any](v T) *T { return &v }
-
 // NewClient creates a new Todoist API client.
 func NewClient(token string, opts ...Option) *Client {
 	c := &Client{

--- a/internal/todoist/client.go
+++ b/internal/todoist/client.go
@@ -38,6 +38,9 @@ func WithBaseURL(url string) Option {
 	return func(cl *Client) { cl.baseURL = url }
 }
 
+// Ptr returns a pointer to v. Convenience for building request structs.
+func Ptr[T any](v T) *T { return &v }
+
 // NewClient creates a new Todoist API client.
 func NewClient(token string, opts ...Option) *Client {
 	c := &Client{

--- a/internal/todoist/client_test.go
+++ b/internal/todoist/client_test.go
@@ -1,6 +1,7 @@
 package todoist
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -44,7 +45,7 @@ func TestDo_setsAuthHeader(t *testing.T) {
 	})
 	defer srv.Close()
 
-	_, err := c.do("GET", "/test", nil)
+	_, err := c.do(context.Background(), "GET", "/test", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,7 +58,7 @@ func TestDo_errorStatus(t *testing.T) {
 	})
 	defer srv.Close()
 
-	_, err := c.do("GET", "/test", nil)
+	_, err := c.do(context.Background(), "GET", "/test", nil)
 	if err == nil {
 		t.Fatal("expected error for 401")
 	}
@@ -74,7 +75,7 @@ func TestDo_sendsJSONBody(t *testing.T) {
 	})
 	defer srv.Close()
 
-	_, err := c.do("POST", "/test", map[string]string{"key": "val"})
+	_, err := c.do(context.Background(), "POST", "/test", map[string]string{"key": "val"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/todoist/comments.go
+++ b/internal/todoist/comments.go
@@ -1,6 +1,7 @@
 package todoist
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -10,7 +11,7 @@ import (
 
 // GetComments returns comments for a task or project.
 // Exactly one of taskID or projectID should be non-empty.
-func (c *Client) GetComments(taskID, projectID string) ([]models.Comment, error) {
+func (c *Client) GetComments(ctx context.Context, taskID, projectID string) ([]models.Comment, error) {
 	endpoint := "/comments"
 	values := url.Values{}
 	if taskID != "" {
@@ -22,7 +23,7 @@ func (c *Client) GetComments(taskID, projectID string) ([]models.Comment, error)
 		endpoint += "?" + values.Encode()
 	}
 
-	data, err := c.do("GET", endpoint, nil)
+	data, err := c.do(ctx, "GET", endpoint, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -35,8 +36,8 @@ func (c *Client) GetComments(taskID, projectID string) ([]models.Comment, error)
 }
 
 // CreateComment creates a new comment.
-func (c *Client) CreateComment(body map[string]any) (*models.Comment, error) {
-	data, err := c.do("POST", "/comments", body)
+func (c *Client) CreateComment(ctx context.Context, body map[string]any) (*models.Comment, error) {
+	data, err := c.do(ctx, "POST", "/comments", body)
 	if err != nil {
 		return nil, err
 	}
@@ -49,8 +50,8 @@ func (c *Client) CreateComment(body map[string]any) (*models.Comment, error) {
 }
 
 // UpdateComment updates an existing comment.
-func (c *Client) UpdateComment(id string, body map[string]any) (*models.Comment, error) {
-	data, err := c.do("POST", "/comments/"+id, body)
+func (c *Client) UpdateComment(ctx context.Context, id string, body map[string]any) (*models.Comment, error) {
+	data, err := c.do(ctx, "POST", "/comments/"+id, body)
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +64,7 @@ func (c *Client) UpdateComment(id string, body map[string]any) (*models.Comment,
 }
 
 // DeleteComment deletes a comment.
-func (c *Client) DeleteComment(id string) error {
-	_, err := c.do("DELETE", "/comments/"+id, nil)
+func (c *Client) DeleteComment(ctx context.Context, id string) error {
+	_, err := c.do(ctx, "DELETE", "/comments/"+id, nil)
 	return err
 }

--- a/internal/todoist/comments.go
+++ b/internal/todoist/comments.go
@@ -35,9 +35,21 @@ func (c *Client) GetComments(ctx context.Context, taskID, projectID string) ([]m
 	return page.Results, nil
 }
 
+// CreateCommentRequest is the request body for creating a comment.
+type CreateCommentRequest struct {
+	Content   string  `json:"content"`
+	TaskID    *string `json:"task_id,omitempty"`
+	ProjectID *string `json:"project_id,omitempty"`
+}
+
+// UpdateCommentRequest is the request body for updating a comment.
+type UpdateCommentRequest struct {
+	Content string `json:"content"`
+}
+
 // CreateComment creates a new comment.
-func (c *Client) CreateComment(ctx context.Context, body map[string]any) (*models.Comment, error) {
-	data, err := c.do(ctx, "POST", "/comments", body)
+func (c *Client) CreateComment(ctx context.Context, req CreateCommentRequest) (*models.Comment, error) {
+	data, err := c.do(ctx, "POST", "/comments", req)
 	if err != nil {
 		return nil, err
 	}
@@ -50,8 +62,8 @@ func (c *Client) CreateComment(ctx context.Context, body map[string]any) (*model
 }
 
 // UpdateComment updates an existing comment.
-func (c *Client) UpdateComment(ctx context.Context, id string, body map[string]any) (*models.Comment, error) {
-	data, err := c.do(ctx, "POST", "/comments/"+id, body)
+func (c *Client) UpdateComment(ctx context.Context, id string, req UpdateCommentRequest) (*models.Comment, error) {
+	data, err := c.do(ctx, "POST", "/comments/"+id, req)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/todoist/comments_test.go
+++ b/internal/todoist/comments_test.go
@@ -36,7 +36,7 @@ func TestCreateComment(t *testing.T) {
 	})
 	defer srv.Close()
 
-	cm, err := c.CreateComment(context.Background(), CreateCommentRequest{Content: "New comment", TaskID: Ptr("42")})
+	cm, err := c.CreateComment(context.Background(), CreateCommentRequest{Content: "New comment", TaskID: new("42")})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/todoist/comments_test.go
+++ b/internal/todoist/comments_test.go
@@ -1,6 +1,7 @@
 package todoist
 
 import (
+	"context"
 	"net/http"
 	"testing"
 )
@@ -17,7 +18,7 @@ func TestGetComments(t *testing.T) {
 	})
 	defer srv.Close()
 
-	comments, err := c.GetComments("42", "")
+	comments, err := c.GetComments(context.Background(), "42", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -35,7 +36,7 @@ func TestCreateComment(t *testing.T) {
 	})
 	defer srv.Close()
 
-	cm, err := c.CreateComment(map[string]any{"content": "New comment", "task_id": "42"})
+	cm, err := c.CreateComment(context.Background(), map[string]any{"content": "New comment", "task_id": "42"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +56,7 @@ func TestGetComments_noParams(t *testing.T) {
 	})
 	defer srv.Close()
 
-	_, err := c.GetComments("", "")
+	_, err := c.GetComments(context.Background(), "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -76,7 +77,7 @@ func TestGetComments_byProject(t *testing.T) {
 	})
 	defer srv.Close()
 
-	_, err := c.GetComments("", "p1")
+	_, err := c.GetComments(context.Background(), "", "p1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -91,7 +92,7 @@ func TestDeleteComment(t *testing.T) {
 	})
 	defer srv.Close()
 
-	if err := c.DeleteComment("c1"); err != nil {
+	if err := c.DeleteComment(context.Background(), "c1"); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/todoist/comments_test.go
+++ b/internal/todoist/comments_test.go
@@ -36,7 +36,7 @@ func TestCreateComment(t *testing.T) {
 	})
 	defer srv.Close()
 
-	cm, err := c.CreateComment(context.Background(), map[string]any{"content": "New comment", "task_id": "42"})
+	cm, err := c.CreateComment(context.Background(), CreateCommentRequest{Content: "New comment", TaskID: Ptr("42")})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/todoist/labels.go
+++ b/internal/todoist/labels.go
@@ -22,9 +22,22 @@ func (c *Client) GetLabels(ctx context.Context) ([]models.Label, error) {
 	return page.Results, nil
 }
 
+// CreateLabelRequest is the request body for creating a label.
+type CreateLabelRequest struct {
+	Name       string  `json:"name"`
+	Color      *string `json:"color,omitempty"`
+	IsFavorite *bool   `json:"is_favorite,omitempty"`
+}
+
+// UpdateLabelRequest is the request body for updating a label.
+type UpdateLabelRequest struct {
+	Name  *string `json:"name,omitempty"`
+	Color *string `json:"color,omitempty"`
+}
+
 // CreateLabel creates a new personal label.
-func (c *Client) CreateLabel(ctx context.Context, body map[string]any) (*models.Label, error) {
-	data, err := c.do(ctx, "POST", "/labels", body)
+func (c *Client) CreateLabel(ctx context.Context, req CreateLabelRequest) (*models.Label, error) {
+	data, err := c.do(ctx, "POST", "/labels", req)
 	if err != nil {
 		return nil, err
 	}
@@ -37,8 +50,8 @@ func (c *Client) CreateLabel(ctx context.Context, body map[string]any) (*models.
 }
 
 // UpdateLabel updates an existing label.
-func (c *Client) UpdateLabel(ctx context.Context, id string, body map[string]any) (*models.Label, error) {
-	data, err := c.do(ctx, "POST", "/labels/"+id, body)
+func (c *Client) UpdateLabel(ctx context.Context, id string, req UpdateLabelRequest) (*models.Label, error) {
+	data, err := c.do(ctx, "POST", "/labels/"+id, req)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/todoist/labels.go
+++ b/internal/todoist/labels.go
@@ -1,6 +1,7 @@
 package todoist
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -8,8 +9,8 @@ import (
 )
 
 // GetLabels returns all personal labels.
-func (c *Client) GetLabels() ([]models.Label, error) {
-	data, err := c.do("GET", "/labels", nil)
+func (c *Client) GetLabels(ctx context.Context) ([]models.Label, error) {
+	data, err := c.do(ctx, "GET", "/labels", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -22,8 +23,8 @@ func (c *Client) GetLabels() ([]models.Label, error) {
 }
 
 // CreateLabel creates a new personal label.
-func (c *Client) CreateLabel(body map[string]any) (*models.Label, error) {
-	data, err := c.do("POST", "/labels", body)
+func (c *Client) CreateLabel(ctx context.Context, body map[string]any) (*models.Label, error) {
+	data, err := c.do(ctx, "POST", "/labels", body)
 	if err != nil {
 		return nil, err
 	}
@@ -36,8 +37,8 @@ func (c *Client) CreateLabel(body map[string]any) (*models.Label, error) {
 }
 
 // UpdateLabel updates an existing label.
-func (c *Client) UpdateLabel(id string, body map[string]any) (*models.Label, error) {
-	data, err := c.do("POST", "/labels/"+id, body)
+func (c *Client) UpdateLabel(ctx context.Context, id string, body map[string]any) (*models.Label, error) {
+	data, err := c.do(ctx, "POST", "/labels/"+id, body)
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +51,7 @@ func (c *Client) UpdateLabel(id string, body map[string]any) (*models.Label, err
 }
 
 // DeleteLabel deletes a label.
-func (c *Client) DeleteLabel(id string) error {
-	_, err := c.do("DELETE", "/labels/"+id, nil)
+func (c *Client) DeleteLabel(ctx context.Context, id string) error {
+	_, err := c.do(ctx, "DELETE", "/labels/"+id, nil)
 	return err
 }

--- a/internal/todoist/labels_test.go
+++ b/internal/todoist/labels_test.go
@@ -33,7 +33,7 @@ func TestCreateLabel(t *testing.T) {
 	})
 	defer srv.Close()
 
-	l, err := c.CreateLabel(context.Background(), map[string]any{"name": "waiting"})
+	l, err := c.CreateLabel(context.Background(), CreateLabelRequest{Name: "waiting"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/todoist/labels_test.go
+++ b/internal/todoist/labels_test.go
@@ -1,6 +1,7 @@
 package todoist
 
 import (
+	"context"
 	"net/http"
 	"testing"
 )
@@ -14,7 +15,7 @@ func TestGetLabels(t *testing.T) {
 	})
 	defer srv.Close()
 
-	labels, err := c.GetLabels()
+	labels, err := c.GetLabels(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -32,7 +33,7 @@ func TestCreateLabel(t *testing.T) {
 	})
 	defer srv.Close()
 
-	l, err := c.CreateLabel(map[string]any{"name": "waiting"})
+	l, err := c.CreateLabel(context.Background(), map[string]any{"name": "waiting"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,7 +51,7 @@ func TestDeleteLabel(t *testing.T) {
 	})
 	defer srv.Close()
 
-	if err := c.DeleteLabel("l1"); err != nil {
+	if err := c.DeleteLabel(context.Background(), "l1"); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/todoist/projects.go
+++ b/internal/todoist/projects.go
@@ -36,9 +36,25 @@ func (c *Client) GetProject(ctx context.Context, id string) (*models.Project, er
 	return &project, nil
 }
 
+// CreateProjectRequest is the request body for creating a project.
+type CreateProjectRequest struct {
+	Name       string  `json:"name"`
+	ParentID   *string `json:"parent_id,omitempty"`
+	Color      *string `json:"color,omitempty"`
+	IsFavorite *bool   `json:"is_favorite,omitempty"`
+	ViewStyle  *string `json:"view_style,omitempty"`
+}
+
+// UpdateProjectRequest is the request body for updating a project.
+type UpdateProjectRequest struct {
+	Name       *string `json:"name,omitempty"`
+	Color      *string `json:"color,omitempty"`
+	IsFavorite *bool   `json:"is_favorite,omitempty"`
+}
+
 // CreateProject creates a new project.
-func (c *Client) CreateProject(ctx context.Context, body map[string]any) (*models.Project, error) {
-	data, err := c.do(ctx, "POST", "/projects", body)
+func (c *Client) CreateProject(ctx context.Context, req CreateProjectRequest) (*models.Project, error) {
+	data, err := c.do(ctx, "POST", "/projects", req)
 	if err != nil {
 		return nil, err
 	}
@@ -51,8 +67,8 @@ func (c *Client) CreateProject(ctx context.Context, body map[string]any) (*model
 }
 
 // UpdateProject updates an existing project.
-func (c *Client) UpdateProject(ctx context.Context, id string, body map[string]any) (*models.Project, error) {
-	data, err := c.do(ctx, "POST", "/projects/"+id, body)
+func (c *Client) UpdateProject(ctx context.Context, id string, req UpdateProjectRequest) (*models.Project, error) {
+	data, err := c.do(ctx, "POST", "/projects/"+id, req)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/todoist/projects.go
+++ b/internal/todoist/projects.go
@@ -1,6 +1,7 @@
 package todoist
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -8,8 +9,8 @@ import (
 )
 
 // GetProjects returns all projects.
-func (c *Client) GetProjects() ([]models.Project, error) {
-	data, err := c.do("GET", "/projects", nil)
+func (c *Client) GetProjects(ctx context.Context) ([]models.Project, error) {
+	data, err := c.do(ctx, "GET", "/projects", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -22,8 +23,8 @@ func (c *Client) GetProjects() ([]models.Project, error) {
 }
 
 // GetProject returns a single project by ID.
-func (c *Client) GetProject(id string) (*models.Project, error) {
-	data, err := c.do("GET", "/projects/"+id, nil)
+func (c *Client) GetProject(ctx context.Context, id string) (*models.Project, error) {
+	data, err := c.do(ctx, "GET", "/projects/"+id, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -36,8 +37,8 @@ func (c *Client) GetProject(id string) (*models.Project, error) {
 }
 
 // CreateProject creates a new project.
-func (c *Client) CreateProject(body map[string]any) (*models.Project, error) {
-	data, err := c.do("POST", "/projects", body)
+func (c *Client) CreateProject(ctx context.Context, body map[string]any) (*models.Project, error) {
+	data, err := c.do(ctx, "POST", "/projects", body)
 	if err != nil {
 		return nil, err
 	}
@@ -50,8 +51,8 @@ func (c *Client) CreateProject(body map[string]any) (*models.Project, error) {
 }
 
 // UpdateProject updates an existing project.
-func (c *Client) UpdateProject(id string, body map[string]any) (*models.Project, error) {
-	data, err := c.do("POST", "/projects/"+id, body)
+func (c *Client) UpdateProject(ctx context.Context, id string, body map[string]any) (*models.Project, error) {
+	data, err := c.do(ctx, "POST", "/projects/"+id, body)
 	if err != nil {
 		return nil, err
 	}
@@ -64,19 +65,19 @@ func (c *Client) UpdateProject(id string, body map[string]any) (*models.Project,
 }
 
 // DeleteProject deletes a project.
-func (c *Client) DeleteProject(id string) error {
-	_, err := c.do("DELETE", "/projects/"+id, nil)
+func (c *Client) DeleteProject(ctx context.Context, id string) error {
+	_, err := c.do(ctx, "DELETE", "/projects/"+id, nil)
 	return err
 }
 
 // ArchiveProject archives a project.
-func (c *Client) ArchiveProject(id string) error {
-	_, err := c.do("POST", "/projects/"+id+"/archive", nil)
+func (c *Client) ArchiveProject(ctx context.Context, id string) error {
+	_, err := c.do(ctx, "POST", "/projects/"+id+"/archive", nil)
 	return err
 }
 
 // UnarchiveProject unarchives a project.
-func (c *Client) UnarchiveProject(id string) error {
-	_, err := c.do("POST", "/projects/"+id+"/unarchive", nil)
+func (c *Client) UnarchiveProject(ctx context.Context, id string) error {
+	_, err := c.do(ctx, "POST", "/projects/"+id+"/unarchive", nil)
 	return err
 }

--- a/internal/todoist/projects_test.go
+++ b/internal/todoist/projects_test.go
@@ -1,6 +1,7 @@
 package todoist
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -15,7 +16,7 @@ func TestGetProjects(t *testing.T) {
 	})
 	defer srv.Close()
 
-	projects, err := c.GetProjects()
+	projects, err := c.GetProjects(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -33,7 +34,7 @@ func TestGetProject(t *testing.T) {
 	})
 	defer srv.Close()
 
-	p, err := c.GetProject("200")
+	p, err := c.GetProject(context.Background(), "200")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,7 +59,7 @@ func TestCreateProject(t *testing.T) {
 	})
 	defer srv.Close()
 
-	p, err := c.CreateProject(map[string]any{"name": "New Project"})
+	p, err := c.CreateProject(context.Background(), map[string]any{"name": "New Project"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -76,7 +77,7 @@ func TestDeleteProject(t *testing.T) {
 	})
 	defer srv.Close()
 
-	if err := c.DeleteProject("300"); err != nil {
+	if err := c.DeleteProject(context.Background(), "300"); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -90,7 +91,7 @@ func TestArchiveProject(t *testing.T) {
 	})
 	defer srv.Close()
 
-	if err := c.ArchiveProject("300"); err != nil {
+	if err := c.ArchiveProject(context.Background(), "300"); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -104,7 +105,7 @@ func TestUnarchiveProject(t *testing.T) {
 	})
 	defer srv.Close()
 
-	if err := c.UnarchiveProject("300"); err != nil {
+	if err := c.UnarchiveProject(context.Background(), "300"); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/todoist/projects_test.go
+++ b/internal/todoist/projects_test.go
@@ -59,7 +59,7 @@ func TestCreateProject(t *testing.T) {
 	})
 	defer srv.Close()
 
-	p, err := c.CreateProject(context.Background(), map[string]any{"name": "New Project"})
+	p, err := c.CreateProject(context.Background(), CreateProjectRequest{Name: "New Project"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/todoist/sections.go
+++ b/internal/todoist/sections.go
@@ -1,6 +1,7 @@
 package todoist
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -9,7 +10,7 @@ import (
 )
 
 // GetSections returns sections, optionally filtered by project.
-func (c *Client) GetSections(projectID string) ([]models.Section, error) {
+func (c *Client) GetSections(ctx context.Context, projectID string) ([]models.Section, error) {
 	endpoint := "/sections"
 	if projectID != "" {
 		values := url.Values{}
@@ -17,7 +18,7 @@ func (c *Client) GetSections(projectID string) ([]models.Section, error) {
 		endpoint += "?" + values.Encode()
 	}
 
-	data, err := c.do("GET", endpoint, nil)
+	data, err := c.do(ctx, "GET", endpoint, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -30,8 +31,8 @@ func (c *Client) GetSections(projectID string) ([]models.Section, error) {
 }
 
 // CreateSection creates a new section.
-func (c *Client) CreateSection(body map[string]any) (*models.Section, error) {
-	data, err := c.do("POST", "/sections", body)
+func (c *Client) CreateSection(ctx context.Context, body map[string]any) (*models.Section, error) {
+	data, err := c.do(ctx, "POST", "/sections", body)
 	if err != nil {
 		return nil, err
 	}
@@ -44,8 +45,8 @@ func (c *Client) CreateSection(body map[string]any) (*models.Section, error) {
 }
 
 // UpdateSection updates an existing section.
-func (c *Client) UpdateSection(id string, body map[string]any) (*models.Section, error) {
-	data, err := c.do("POST", "/sections/"+id, body)
+func (c *Client) UpdateSection(ctx context.Context, id string, body map[string]any) (*models.Section, error) {
+	data, err := c.do(ctx, "POST", "/sections/"+id, body)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +59,7 @@ func (c *Client) UpdateSection(id string, body map[string]any) (*models.Section,
 }
 
 // DeleteSection deletes a section.
-func (c *Client) DeleteSection(id string) error {
-	_, err := c.do("DELETE", "/sections/"+id, nil)
+func (c *Client) DeleteSection(ctx context.Context, id string) error {
+	_, err := c.do(ctx, "DELETE", "/sections/"+id, nil)
 	return err
 }

--- a/internal/todoist/sections.go
+++ b/internal/todoist/sections.go
@@ -30,9 +30,21 @@ func (c *Client) GetSections(ctx context.Context, projectID string) ([]models.Se
 	return page.Results, nil
 }
 
+// CreateSectionRequest is the request body for creating a section.
+type CreateSectionRequest struct {
+	Name         string `json:"name"`
+	ProjectID    string `json:"project_id"`
+	SectionOrder *int   `json:"section_order,omitempty"`
+}
+
+// UpdateSectionRequest is the request body for updating a section.
+type UpdateSectionRequest struct {
+	Name string `json:"name"`
+}
+
 // CreateSection creates a new section.
-func (c *Client) CreateSection(ctx context.Context, body map[string]any) (*models.Section, error) {
-	data, err := c.do(ctx, "POST", "/sections", body)
+func (c *Client) CreateSection(ctx context.Context, req CreateSectionRequest) (*models.Section, error) {
+	data, err := c.do(ctx, "POST", "/sections", req)
 	if err != nil {
 		return nil, err
 	}
@@ -45,8 +57,8 @@ func (c *Client) CreateSection(ctx context.Context, body map[string]any) (*model
 }
 
 // UpdateSection updates an existing section.
-func (c *Client) UpdateSection(ctx context.Context, id string, body map[string]any) (*models.Section, error) {
-	data, err := c.do(ctx, "POST", "/sections/"+id, body)
+func (c *Client) UpdateSection(ctx context.Context, id string, req UpdateSectionRequest) (*models.Section, error) {
+	data, err := c.do(ctx, "POST", "/sections/"+id, req)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/todoist/sections_test.go
+++ b/internal/todoist/sections_test.go
@@ -1,6 +1,7 @@
 package todoist
 
 import (
+	"context"
 	"net/http"
 	"testing"
 )
@@ -17,7 +18,7 @@ func TestGetSections(t *testing.T) {
 	})
 	defer srv.Close()
 
-	sections, err := c.GetSections("123")
+	sections, err := c.GetSections(context.Background(), "123")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -35,7 +36,7 @@ func TestCreateSection(t *testing.T) {
 	})
 	defer srv.Close()
 
-	sec, err := c.CreateSection(map[string]any{"name": "In Progress", "project_id": "123"})
+	sec, err := c.CreateSection(context.Background(), map[string]any{"name": "In Progress", "project_id": "123"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -53,7 +54,7 @@ func TestDeleteSection(t *testing.T) {
 	})
 	defer srv.Close()
 
-	if err := c.DeleteSection("s1"); err != nil {
+	if err := c.DeleteSection(context.Background(), "s1"); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/todoist/sections_test.go
+++ b/internal/todoist/sections_test.go
@@ -36,7 +36,7 @@ func TestCreateSection(t *testing.T) {
 	})
 	defer srv.Close()
 
-	sec, err := c.CreateSection(context.Background(), map[string]any{"name": "In Progress", "project_id": "123"})
+	sec, err := c.CreateSection(context.Background(), CreateSectionRequest{Name: "In Progress", ProjectID: "123"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/todoist/tasks.go
+++ b/internal/todoist/tasks.go
@@ -119,9 +119,43 @@ func (c *Client) GetTask(ctx context.Context, id string) (*models.Task, error) {
 	return &task, nil
 }
 
+// CreateTaskRequest is the request body for creating a task.
+type CreateTaskRequest struct {
+	Content     string   `json:"content"`
+	Description *string  `json:"description,omitempty"`
+	DueString   *string  `json:"due_string,omitempty"`
+	Priority    *int     `json:"priority,omitempty"`
+	ProjectID   *string  `json:"project_id,omitempty"`
+	SectionID   *string  `json:"section_id,omitempty"`
+	ParentID    *string  `json:"parent_id,omitempty"`
+	Labels      []string `json:"labels,omitempty"`
+	AssigneeID  *string  `json:"assignee_id,omitempty"`
+}
+
+// UpdateTaskRequest is the request body for updating a task.
+//
+// Labels is *[]string so a pointer to an empty slice can express
+// "clear all labels"; omitempty on a plain slice would drop it.
+type UpdateTaskRequest struct {
+	Content      *string   `json:"content,omitempty"`
+	Description  *string   `json:"description,omitempty"`
+	DueString    *string   `json:"due_string,omitempty"`
+	Priority     *int      `json:"priority,omitempty"`
+	Labels       *[]string `json:"labels,omitempty"`
+	AssigneeID   *string   `json:"assignee_id,omitempty"`
+	DeadlineDate *string   `json:"deadline_date,omitempty"`
+}
+
+// MoveTaskRequest moves a task. Set exactly one field.
+type MoveTaskRequest struct {
+	ProjectID *string `json:"project_id,omitempty"`
+	SectionID *string `json:"section_id,omitempty"`
+	ParentID  *string `json:"parent_id,omitempty"`
+}
+
 // CreateTask creates a new task.
-func (c *Client) CreateTask(ctx context.Context, body map[string]any) (*models.Task, error) {
-	data, err := c.do(ctx, "POST", "/tasks", body)
+func (c *Client) CreateTask(ctx context.Context, req CreateTaskRequest) (*models.Task, error) {
+	data, err := c.do(ctx, "POST", "/tasks", req)
 	if err != nil {
 		return nil, err
 	}
@@ -134,8 +168,8 @@ func (c *Client) CreateTask(ctx context.Context, body map[string]any) (*models.T
 }
 
 // UpdateTask updates an existing task.
-func (c *Client) UpdateTask(ctx context.Context, id string, body map[string]any) (*models.Task, error) {
-	data, err := c.do(ctx, "POST", "/tasks/"+id, body)
+func (c *Client) UpdateTask(ctx context.Context, id string, req UpdateTaskRequest) (*models.Task, error) {
+	data, err := c.do(ctx, "POST", "/tasks/"+id, req)
 	if err != nil {
 		return nil, err
 	}
@@ -148,9 +182,9 @@ func (c *Client) UpdateTask(ctx context.Context, id string, body map[string]any)
 }
 
 // MoveTask moves a task to another project, section, or parent.
-// The body must set exactly one of project_id, section_id, parent_id.
-func (c *Client) MoveTask(ctx context.Context, id string, body map[string]any) (*models.Task, error) {
-	data, err := c.do(ctx, "POST", "/tasks/"+id+"/move", body)
+// The request must set exactly one of ProjectID, SectionID, ParentID.
+func (c *Client) MoveTask(ctx context.Context, id string, req MoveTaskRequest) (*models.Task, error) {
+	data, err := c.do(ctx, "POST", "/tasks/"+id+"/move", req)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/todoist/tasks.go
+++ b/internal/todoist/tasks.go
@@ -1,6 +1,7 @@
 package todoist
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -29,7 +30,7 @@ func (r *filteredTasksResponse) tasks() []models.Task {
 }
 
 // getTasksPage returns one page of active tasks plus the cursor for the next page.
-func (c *Client) getTasksPage(projectID, cursor string) ([]models.Task, string, error) {
+func (c *Client) getTasksPage(ctx context.Context, projectID, cursor string) ([]models.Task, string, error) {
 	endpoint := "/tasks"
 	values := url.Values{}
 	if projectID != "" {
@@ -42,7 +43,7 @@ func (c *Client) getTasksPage(projectID, cursor string) ([]models.Task, string, 
 		endpoint += "?" + values.Encode()
 	}
 
-	data, err := c.do("GET", endpoint, nil)
+	data, err := c.do(ctx, "GET", endpoint, nil)
 	if err != nil {
 		return nil, "", err
 	}
@@ -55,13 +56,13 @@ func (c *Client) getTasksPage(projectID, cursor string) ([]models.Task, string, 
 }
 
 // GetTasks returns the first page of active tasks, optionally filtered by project.
-func (c *Client) GetTasks(projectID string) ([]models.Task, error) {
-	tasks, _, err := c.getTasksPage(projectID, "")
+func (c *Client) GetTasks(ctx context.Context, projectID string) ([]models.Task, error) {
+	tasks, _, err := c.getTasksPage(ctx, projectID, "")
 	return tasks, err
 }
 
 // getFilteredTasksPage returns one page of filtered tasks plus the cursor for the next page.
-func (c *Client) getFilteredTasksPage(query, cursor string) ([]models.Task, string, error) {
+func (c *Client) getFilteredTasksPage(ctx context.Context, query, cursor string) ([]models.Task, string, error) {
 	values := url.Values{}
 	values.Set("query", query)
 	if cursor != "" {
@@ -71,7 +72,7 @@ func (c *Client) getFilteredTasksPage(query, cursor string) ([]models.Task, stri
 
 	slog.Debug("todoist filter request", "endpoint", endpoint)
 
-	data, err := c.do("GET", endpoint, nil)
+	data, err := c.do(ctx, "GET", endpoint, nil)
 	if err != nil {
 		return nil, "", err
 	}
@@ -87,11 +88,11 @@ func (c *Client) getFilteredTasksPage(query, cursor string) ([]models.Task, stri
 
 // GetTasksByFilter returns tasks matching a Todoist filter query using the
 // dedicated /tasks/filter endpoint. It paginates up to maxFindPages pages.
-func (c *Client) GetTasksByFilter(query string) ([]models.Task, error) {
+func (c *Client) GetTasksByFilter(ctx context.Context, query string) ([]models.Task, error) {
 	var all []models.Task
 	cursor := ""
 	for range maxFindPages {
-		tasks, nextCursor, err := c.getFilteredTasksPage(query, cursor)
+		tasks, nextCursor, err := c.getFilteredTasksPage(ctx, query, cursor)
 		if err != nil {
 			return nil, err
 		}
@@ -105,8 +106,8 @@ func (c *Client) GetTasksByFilter(query string) ([]models.Task, error) {
 }
 
 // GetTask returns a single task by ID.
-func (c *Client) GetTask(id string) (*models.Task, error) {
-	data, err := c.do("GET", "/tasks/"+id, nil)
+func (c *Client) GetTask(ctx context.Context, id string) (*models.Task, error) {
+	data, err := c.do(ctx, "GET", "/tasks/"+id, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -119,8 +120,8 @@ func (c *Client) GetTask(id string) (*models.Task, error) {
 }
 
 // CreateTask creates a new task.
-func (c *Client) CreateTask(body map[string]any) (*models.Task, error) {
-	data, err := c.do("POST", "/tasks", body)
+func (c *Client) CreateTask(ctx context.Context, body map[string]any) (*models.Task, error) {
+	data, err := c.do(ctx, "POST", "/tasks", body)
 	if err != nil {
 		return nil, err
 	}
@@ -133,8 +134,8 @@ func (c *Client) CreateTask(body map[string]any) (*models.Task, error) {
 }
 
 // UpdateTask updates an existing task.
-func (c *Client) UpdateTask(id string, body map[string]any) (*models.Task, error) {
-	data, err := c.do("POST", "/tasks/"+id, body)
+func (c *Client) UpdateTask(ctx context.Context, id string, body map[string]any) (*models.Task, error) {
+	data, err := c.do(ctx, "POST", "/tasks/"+id, body)
 	if err != nil {
 		return nil, err
 	}
@@ -148,8 +149,8 @@ func (c *Client) UpdateTask(id string, body map[string]any) (*models.Task, error
 
 // MoveTask moves a task to another project, section, or parent.
 // The body must set exactly one of project_id, section_id, parent_id.
-func (c *Client) MoveTask(id string, body map[string]any) (*models.Task, error) {
-	data, err := c.do("POST", "/tasks/"+id+"/move", body)
+func (c *Client) MoveTask(ctx context.Context, id string, body map[string]any) (*models.Task, error) {
+	data, err := c.do(ctx, "POST", "/tasks/"+id+"/move", body)
 	if err != nil {
 		return nil, err
 	}
@@ -162,20 +163,20 @@ func (c *Client) MoveTask(id string, body map[string]any) (*models.Task, error) 
 }
 
 // DeleteTask deletes a task.
-func (c *Client) DeleteTask(id string) error {
-	_, err := c.do("DELETE", "/tasks/"+id, nil)
+func (c *Client) DeleteTask(ctx context.Context, id string) error {
+	_, err := c.do(ctx, "DELETE", "/tasks/"+id, nil)
 	return err
 }
 
 // CloseTask marks a task as complete.
-func (c *Client) CloseTask(id string) error {
-	_, err := c.do("POST", "/tasks/"+id+"/close", nil)
+func (c *Client) CloseTask(ctx context.Context, id string) error {
+	_, err := c.do(ctx, "POST", "/tasks/"+id+"/close", nil)
 	return err
 }
 
 // ReopenTask reopens a completed task.
-func (c *Client) ReopenTask(id string) error {
-	_, err := c.do("POST", "/tasks/"+id+"/reopen", nil)
+func (c *Client) ReopenTask(ctx context.Context, id string) error {
+	_, err := c.do(ctx, "POST", "/tasks/"+id+"/reopen", nil)
 	return err
 }
 
@@ -192,13 +193,13 @@ const maxFindPages = 20
 
 // FindTaskByName searches for a task by partial name matching across all pages.
 // Exact matches take priority over partial matches. Returns nil if no match is found.
-func (c *Client) FindTaskByName(name string) (*models.Task, error) {
+func (c *Client) FindTaskByName(ctx context.Context, name string) (*models.Task, error) {
 	norm := strings.ToLower(normalizeWhitespace(name))
 
 	var partial *models.Task
 	cursor := ""
 	for range maxFindPages {
-		tasks, nextCursor, err := c.getTasksPage("", cursor)
+		tasks, nextCursor, err := c.getTasksPage(ctx, "", cursor)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/todoist/tasks_test.go
+++ b/internal/todoist/tasks_test.go
@@ -83,7 +83,7 @@ func TestCreateTask(t *testing.T) {
 	})
 	defer srv.Close()
 
-	task, err := c.CreateTask(context.Background(), map[string]any{"content": "New task"})
+	task, err := c.CreateTask(context.Background(), CreateTaskRequest{Content: "New task"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,7 +101,7 @@ func TestUpdateTask(t *testing.T) {
 	})
 	defer srv.Close()
 
-	task, err := c.UpdateTask(context.Background(), "10", map[string]any{"content": "Updated"})
+	task, err := c.UpdateTask(context.Background(), "10", UpdateTaskRequest{Content: Ptr("Updated")})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -119,7 +119,7 @@ func TestMoveTask(t *testing.T) {
 	})
 	defer srv.Close()
 
-	task, err := c.MoveTask(context.Background(), "10", map[string]any{"project_id": "42"})
+	task, err := c.MoveTask(context.Background(), "10", MoveTaskRequest{ProjectID: Ptr("42")})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/todoist/tasks_test.go
+++ b/internal/todoist/tasks_test.go
@@ -101,7 +101,7 @@ func TestUpdateTask(t *testing.T) {
 	})
 	defer srv.Close()
 
-	task, err := c.UpdateTask(context.Background(), "10", UpdateTaskRequest{Content: Ptr("Updated")})
+	task, err := c.UpdateTask(context.Background(), "10", UpdateTaskRequest{Content: new("Updated")})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -119,7 +119,7 @@ func TestMoveTask(t *testing.T) {
 	})
 	defer srv.Close()
 
-	task, err := c.MoveTask(context.Background(), "10", MoveTaskRequest{ProjectID: Ptr("42")})
+	task, err := c.MoveTask(context.Background(), "10", MoveTaskRequest{ProjectID: new("42")})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/todoist/tasks_test.go
+++ b/internal/todoist/tasks_test.go
@@ -1,6 +1,7 @@
 package todoist
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -19,7 +20,7 @@ func TestGetTasks(t *testing.T) {
 	})
 	defer srv.Close()
 
-	tasks, err := c.GetTasks("")
+	tasks, err := c.GetTasks(context.Background(), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -41,7 +42,7 @@ func TestGetTasks_withProjectID(t *testing.T) {
 	})
 	defer srv.Close()
 
-	_, err := c.GetTasks("123")
+	_, err := c.GetTasks(context.Background(), "123")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,7 +57,7 @@ func TestGetTask(t *testing.T) {
 	})
 	defer srv.Close()
 
-	task, err := c.GetTask("42")
+	task, err := c.GetTask(context.Background(), "42")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +83,7 @@ func TestCreateTask(t *testing.T) {
 	})
 	defer srv.Close()
 
-	task, err := c.CreateTask(map[string]any{"content": "New task"})
+	task, err := c.CreateTask(context.Background(), map[string]any{"content": "New task"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -100,7 +101,7 @@ func TestUpdateTask(t *testing.T) {
 	})
 	defer srv.Close()
 
-	task, err := c.UpdateTask("10", map[string]any{"content": "Updated"})
+	task, err := c.UpdateTask(context.Background(), "10", map[string]any{"content": "Updated"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,7 +119,7 @@ func TestMoveTask(t *testing.T) {
 	})
 	defer srv.Close()
 
-	task, err := c.MoveTask("10", map[string]any{"project_id": "42"})
+	task, err := c.MoveTask(context.Background(), "10", map[string]any{"project_id": "42"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -136,7 +137,7 @@ func TestDeleteTask(t *testing.T) {
 	})
 	defer srv.Close()
 
-	if err := c.DeleteTask("5"); err != nil {
+	if err := c.DeleteTask(context.Background(), "5"); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -150,7 +151,7 @@ func TestCloseTask(t *testing.T) {
 	})
 	defer srv.Close()
 
-	if err := c.CloseTask("7"); err != nil {
+	if err := c.CloseTask(context.Background(), "7"); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -164,7 +165,7 @@ func TestReopenTask(t *testing.T) {
 	})
 	defer srv.Close()
 
-	if err := c.ReopenTask("7"); err != nil {
+	if err := c.ReopenTask(context.Background(), "7"); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -184,7 +185,7 @@ func TestGetTasksByFilter(t *testing.T) {
 	})
 	defer srv.Close()
 
-	tasks, err := c.GetTasksByFilter("today")
+	tasks, err := c.GetTasksByFilter(context.Background(), "today")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -213,7 +214,7 @@ func TestGetTasksByFilter_specialChars(t *testing.T) {
 	})
 	defer srv.Close()
 
-	_, err := c.GetTasksByFilter("today & @deep-research")
+	_, err := c.GetTasksByFilter(context.Background(), "today & @deep-research")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -229,7 +230,7 @@ func TestGetTasksByFilter_hashFilter(t *testing.T) {
 	})
 	defer srv.Close()
 
-	_, err := c.GetTasksByFilter("priority 1 & #Work")
+	_, err := c.GetTasksByFilter(context.Background(), "priority 1 & #Work")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -245,7 +246,7 @@ func TestGetTasksByFilter_labelFilter(t *testing.T) {
 	})
 	defer srv.Close()
 
-	tasks, err := c.GetTasksByFilter("@deep-research")
+	tasks, err := c.GetTasksByFilter(context.Background(), "@deep-research")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -264,7 +265,7 @@ func TestGetTasksByFilter_resultsKeyFallback(t *testing.T) {
 	})
 	defer srv.Close()
 
-	tasks, err := c.GetTasksByFilter("today")
+	tasks, err := c.GetTasksByFilter(context.Background(), "today")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -297,7 +298,7 @@ func TestGetTasksByFilter_pagination(t *testing.T) {
 	})
 	defer srv.Close()
 
-	tasks, err := c.GetTasksByFilter("today")
+	tasks, err := c.GetTasksByFilter(context.Background(), "today")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -320,7 +321,7 @@ func TestGetTasksByFilter_maxPagesGuard(t *testing.T) {
 	})
 	defer srv.Close()
 
-	tasks, err := c.GetTasksByFilter("today")
+	tasks, err := c.GetTasksByFilter(context.Background(), "today")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -349,7 +350,7 @@ func TestGetTasksByFilter_apiErrorOnSecondPage(t *testing.T) {
 	})
 	defer srv.Close()
 
-	_, err := c.GetTasksByFilter("today")
+	_, err := c.GetTasksByFilter(context.Background(), "today")
 	if err == nil {
 		t.Fatal("expected error when second page fails, got nil")
 	}
@@ -365,7 +366,7 @@ func TestGetTasksByFilter_apiError(t *testing.T) {
 	})
 	defer srv.Close()
 
-	_, err := c.GetTasksByFilter(")))invalid(((")
+	_, err := c.GetTasksByFilter(context.Background(), ")))invalid(((")
 	if err == nil {
 		t.Fatal("expected error for bad filter, got nil")
 	}
@@ -380,7 +381,7 @@ func TestGetTasksByFilter_emptyResult(t *testing.T) {
 	})
 	defer srv.Close()
 
-	tasks, err := c.GetTasksByFilter("@nonexistent-label")
+	tasks, err := c.GetTasksByFilter(context.Background(), "@nonexistent-label")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -400,7 +401,7 @@ func TestFindTaskByName_exactMatch(t *testing.T) {
 	})
 	defer srv.Close()
 
-	task, err := c.FindTaskByName("Buy groceries")
+	task, err := c.FindTaskByName(context.Background(), "Buy groceries")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -415,7 +416,7 @@ func TestFindTaskByName_partialMatch(t *testing.T) {
 	})
 	defer srv.Close()
 
-	task, err := c.FindTaskByName("team meeting")
+	task, err := c.FindTaskByName(context.Background(), "team meeting")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -430,7 +431,7 @@ func TestFindTaskByName_notFound(t *testing.T) {
 	})
 	defer srv.Close()
 
-	task, err := c.FindTaskByName("nonexistent")
+	task, err := c.FindTaskByName(context.Background(), "nonexistent")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -447,7 +448,7 @@ func TestFindTaskByName_whitespaceNormalization(t *testing.T) {
 	})
 	defer srv.Close()
 
-	task, err := c.FindTaskByName("Buy groceries and milk")
+	task, err := c.FindTaskByName(context.Background(), "Buy groceries and milk")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -465,7 +466,7 @@ func TestFindTaskByName_longTaskName(t *testing.T) {
 	})
 	defer srv.Close()
 
-	task, err := c.FindTaskByName(longName)
+	task, err := c.FindTaskByName(context.Background(), longName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -497,7 +498,7 @@ func TestFindTaskByName_pagination(t *testing.T) {
 	})
 	defer srv.Close()
 
-	task, err := c.FindTaskByName("TEST: verify MCP bug fixes")
+	task, err := c.FindTaskByName(context.Background(), "TEST: verify MCP bug fixes")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -531,7 +532,7 @@ func TestFindTaskByName_exactMatchPriorityAcrossPages(t *testing.T) {
 	})
 	defer srv.Close()
 
-	task, err := c.FindTaskByName("Buy groceries")
+	task, err := c.FindTaskByName(context.Background(), "Buy groceries")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -561,7 +562,7 @@ func TestFindTaskByName_notFoundAcrossPages(t *testing.T) {
 	})
 	defer srv.Close()
 
-	task, err := c.FindTaskByName("nonexistent across pages")
+	task, err := c.FindTaskByName(context.Background(), "nonexistent across pages")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -592,7 +593,7 @@ func TestFindTaskByName_apiErrorOnSecondPage(t *testing.T) {
 	})
 	defer srv.Close()
 
-	_, err := c.FindTaskByName("Target task")
+	_, err := c.FindTaskByName(context.Background(), "Target task")
 	if err == nil {
 		t.Fatal("expected error when second page fails, got nil")
 	}
@@ -612,7 +613,7 @@ func TestFindTaskByName_maxPagesGuard(t *testing.T) {
 	})
 	defer srv.Close()
 
-	task, err := c.FindTaskByName("nonexistent")
+	task, err := c.FindTaskByName(context.Background(), "nonexistent")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/tools/comments.go
+++ b/internal/tools/comments.go
@@ -74,10 +74,10 @@ func registerCommentTools(s *mcp.Server, c *todoist.Client) {
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input CreateCommentInput) (*mcp.CallToolResult, CreateCommentOutput, error) {
 		createReq := todoist.CreateCommentRequest{Content: input.Content}
 		if input.TaskID != "" {
-			createReq.TaskID = todoist.Ptr(input.TaskID)
+			createReq.TaskID = new(input.TaskID)
 		}
 		if input.ProjectID != "" {
-			createReq.ProjectID = todoist.Ptr(input.ProjectID)
+			createReq.ProjectID = new(input.ProjectID)
 		}
 		cm, err := c.CreateComment(ctx, createReq)
 		if err != nil {

--- a/internal/tools/comments.go
+++ b/internal/tools/comments.go
@@ -50,7 +50,7 @@ func registerCommentTools(s *mcp.Server, c *todoist.Client) {
 		Name:        "todoist_get_comments",
 		Description: "List comments for a task or project",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input GetCommentsInput) (*mcp.CallToolResult, GetCommentsOutput, error) {
-		comments, err := c.GetComments(input.TaskID, input.ProjectID)
+		comments, err := c.GetComments(ctx, input.TaskID, input.ProjectID)
 		if err != nil {
 			return nil, GetCommentsOutput{}, err
 		}
@@ -80,7 +80,7 @@ func registerCommentTools(s *mcp.Server, c *todoist.Client) {
 			body["project_id"] = input.ProjectID
 		}
 
-		cm, err := c.CreateComment(body)
+		cm, err := c.CreateComment(ctx, body)
 		if err != nil {
 			return nil, CreateCommentOutput{Success: false, Message: err.Error()}, err
 		}
@@ -94,7 +94,7 @@ func registerCommentTools(s *mcp.Server, c *todoist.Client) {
 		Description: "Update an existing comment",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input UpdateCommentInput) (*mcp.CallToolResult, UpdateCommentOutput, error) {
 		body := map[string]any{"content": input.Content}
-		cm, err := c.UpdateComment(input.CommentID, body)
+		cm, err := c.UpdateComment(ctx, input.CommentID, body)
 		if err != nil {
 			return nil, UpdateCommentOutput{Success: false, Message: err.Error()}, err
 		}
@@ -107,7 +107,7 @@ func registerCommentTools(s *mcp.Server, c *todoist.Client) {
 		Name:        "todoist_delete_comment",
 		Description: "Delete a comment",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input DeleteCommentInput) (*mcp.CallToolResult, DeleteCommentOutput, error) {
-		if err := c.DeleteComment(input.CommentID); err != nil {
+		if err := c.DeleteComment(ctx, input.CommentID); err != nil {
 			return nil, DeleteCommentOutput{Success: false, Message: err.Error()}, err
 		}
 		msg := fmt.Sprintf("Successfully deleted comment: %s", input.CommentID)

--- a/internal/tools/comments.go
+++ b/internal/tools/comments.go
@@ -72,15 +72,14 @@ func registerCommentTools(s *mcp.Server, c *todoist.Client) {
 		Name:        "todoist_create_comment",
 		Description: "Add a comment to a task or project",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input CreateCommentInput) (*mcp.CallToolResult, CreateCommentOutput, error) {
-		body := map[string]any{"content": input.Content}
+		createReq := todoist.CreateCommentRequest{Content: input.Content}
 		if input.TaskID != "" {
-			body["task_id"] = input.TaskID
+			createReq.TaskID = todoist.Ptr(input.TaskID)
 		}
 		if input.ProjectID != "" {
-			body["project_id"] = input.ProjectID
+			createReq.ProjectID = todoist.Ptr(input.ProjectID)
 		}
-
-		cm, err := c.CreateComment(ctx, body)
+		cm, err := c.CreateComment(ctx, createReq)
 		if err != nil {
 			return nil, CreateCommentOutput{Success: false, Message: err.Error()}, err
 		}
@@ -93,8 +92,7 @@ func registerCommentTools(s *mcp.Server, c *todoist.Client) {
 		Name:        "todoist_update_comment",
 		Description: "Update an existing comment",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input UpdateCommentInput) (*mcp.CallToolResult, UpdateCommentOutput, error) {
-		body := map[string]any{"content": input.Content}
-		cm, err := c.UpdateComment(ctx, input.CommentID, body)
+		cm, err := c.UpdateComment(ctx, input.CommentID, todoist.UpdateCommentRequest{Content: input.Content})
 		if err != nil {
 			return nil, UpdateCommentOutput{Success: false, Message: err.Error()}, err
 		}

--- a/internal/tools/gtd.go
+++ b/internal/tools/gtd.go
@@ -225,15 +225,15 @@ func registerGTDTools(s *mcp.Server, c *todoist.Client) {
 		moveReq := todoist.MoveTaskRequest{}
 		dests := 0
 		if input.ProjectID != "" {
-			moveReq.ProjectID = todoist.Ptr(input.ProjectID)
+			moveReq.ProjectID = new(input.ProjectID)
 			dests++
 		}
 		if input.SectionID != "" {
-			moveReq.SectionID = todoist.Ptr(input.SectionID)
+			moveReq.SectionID = new(input.SectionID)
 			dests++
 		}
 		if input.ParentID != "" {
-			moveReq.ParentID = todoist.Ptr(input.ParentID)
+			moveReq.ParentID = new(input.ParentID)
 			dests++
 		}
 		if dests != 1 {
@@ -273,19 +273,19 @@ func registerGTDTools(s *mcp.Server, c *todoist.Client) {
 		for _, item := range input.Tasks {
 			createReq := todoist.CreateTaskRequest{Content: item.Content}
 			if item.Description != "" {
-				createReq.Description = todoist.Ptr(item.Description)
+				createReq.Description = new(item.Description)
 			}
 			if item.DueString != "" {
-				createReq.DueString = todoist.Ptr(item.DueString)
+				createReq.DueString = new(item.DueString)
 			}
 			if item.Priority > 0 && item.Priority <= 4 {
-				createReq.Priority = todoist.Ptr(item.Priority)
+				createReq.Priority = new(item.Priority)
 			}
 			if item.ProjectID != "" {
-				createReq.ProjectID = todoist.Ptr(item.ProjectID)
+				createReq.ProjectID = new(item.ProjectID)
 			}
 			if item.SectionID != "" {
-				createReq.SectionID = todoist.Ptr(item.SectionID)
+				createReq.SectionID = new(item.SectionID)
 			}
 			if len(item.Labels) > 0 {
 				createReq.Labels = item.Labels

--- a/internal/tools/gtd.go
+++ b/internal/tools/gtd.go
@@ -222,18 +222,18 @@ func registerGTDTools(s *mcp.Server, c *todoist.Client) {
 			return textResult(msg, true), MoveTaskOutput{Success: false, Message: msg}, nil
 		}
 
-		body := map[string]any{}
+		moveReq := todoist.MoveTaskRequest{}
 		dests := 0
 		if input.ProjectID != "" {
-			body["project_id"] = input.ProjectID
+			moveReq.ProjectID = todoist.Ptr(input.ProjectID)
 			dests++
 		}
 		if input.SectionID != "" {
-			body["section_id"] = input.SectionID
+			moveReq.SectionID = todoist.Ptr(input.SectionID)
 			dests++
 		}
 		if input.ParentID != "" {
-			body["parent_id"] = input.ParentID
+			moveReq.ParentID = todoist.Ptr(input.ParentID)
 			dests++
 		}
 		if dests != 1 {
@@ -241,7 +241,7 @@ func registerGTDTools(s *mcp.Server, c *todoist.Client) {
 			return textResult(msg, true), MoveTaskOutput{Success: false, Message: msg}, nil
 		}
 
-		_, err = c.MoveTask(ctx, id, body)
+		_, err = c.MoveTask(ctx, id, moveReq)
 		if err != nil {
 			return nil, MoveTaskOutput{Success: false, Message: err.Error()}, err
 		}
@@ -271,27 +271,27 @@ func registerGTDTools(s *mcp.Server, c *todoist.Client) {
 		var lines []string
 
 		for _, item := range input.Tasks {
-			body := map[string]any{"content": item.Content}
+			createReq := todoist.CreateTaskRequest{Content: item.Content}
 			if item.Description != "" {
-				body["description"] = item.Description
+				createReq.Description = todoist.Ptr(item.Description)
 			}
 			if item.DueString != "" {
-				body["due_string"] = item.DueString
+				createReq.DueString = todoist.Ptr(item.DueString)
 			}
 			if item.Priority > 0 && item.Priority <= 4 {
-				body["priority"] = item.Priority
+				createReq.Priority = todoist.Ptr(item.Priority)
 			}
 			if item.ProjectID != "" {
-				body["project_id"] = item.ProjectID
+				createReq.ProjectID = todoist.Ptr(item.ProjectID)
 			}
 			if item.SectionID != "" {
-				body["section_id"] = item.SectionID
+				createReq.SectionID = todoist.Ptr(item.SectionID)
 			}
 			if len(item.Labels) > 0 {
-				body["labels"] = item.Labels
+				createReq.Labels = item.Labels
 			}
 
-			task, err := c.CreateTask(ctx, body)
+			task, err := c.CreateTask(ctx, createReq)
 			if err != nil {
 				failed++
 				lines = append(lines, fmt.Sprintf("FAILED: %s — %s", item.Content, err.Error()))

--- a/internal/tools/gtd.go
+++ b/internal/tools/gtd.go
@@ -68,7 +68,7 @@ func registerGTDTools(s *mcp.Server, c *todoist.Client) {
 		Description: "Get all inbox tasks grouped by age (today, this week, older) for GTD inbox processing",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input InboxReviewInput) (*mcp.CallToolResult, InboxReviewOutput, error) {
 		// Find inbox project.
-		projects, err := c.GetProjects()
+		projects, err := c.GetProjects(ctx)
 		if err != nil {
 			return nil, InboxReviewOutput{}, err
 		}
@@ -85,7 +85,7 @@ func registerGTDTools(s *mcp.Server, c *todoist.Client) {
 			return textResult(msg, true), InboxReviewOutput{Success: false, Message: msg}, nil
 		}
 
-		tasks, err := c.GetTasks(inboxID)
+		tasks, err := c.GetTasks(ctx, inboxID)
 		if err != nil {
 			return nil, InboxReviewOutput{}, err
 		}
@@ -142,12 +142,12 @@ func registerGTDTools(s *mcp.Server, c *todoist.Client) {
 		Name:        "todoist_weekly_review",
 		Description: "Comprehensive weekly review: projects with task counts, overdue tasks, tasks with no due date",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input WeeklyReviewInput) (*mcp.CallToolResult, WeeklyReviewOutput, error) {
-		projects, err := c.GetProjects()
+		projects, err := c.GetProjects(ctx)
 		if err != nil {
 			return nil, WeeklyReviewOutput{}, err
 		}
 
-		allTasks, err := c.GetTasks("")
+		allTasks, err := c.GetTasks(ctx, "")
 		if err != nil {
 			return nil, WeeklyReviewOutput{}, err
 		}
@@ -159,7 +159,7 @@ func registerGTDTools(s *mcp.Server, c *todoist.Client) {
 		}
 
 		// Overdue tasks.
-		overdueTasks, err := c.GetTasksByFilter("overdue")
+		overdueTasks, err := c.GetTasksByFilter(ctx, "overdue")
 		if err != nil {
 			overdueTasks = nil // non-fatal
 		}
@@ -213,7 +213,7 @@ func registerGTDTools(s *mcp.Server, c *todoist.Client) {
 		Name:        "todoist_move_task",
 		Description: "Move a task to a different project, section, or parent. Set exactly one of project_id, section_id, parent_id.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input MoveTaskInput) (*mcp.CallToolResult, MoveTaskOutput, error) {
-		id, originalName, err := resolveTaskID(c, input.TaskID, input.TaskName)
+		id, originalName, err := resolveTaskID(ctx, c, input.TaskID, input.TaskName)
 		if err != nil {
 			return nil, MoveTaskOutput{Success: false, Message: err.Error()}, err
 		}
@@ -241,7 +241,7 @@ func registerGTDTools(s *mcp.Server, c *todoist.Client) {
 			return textResult(msg, true), MoveTaskOutput{Success: false, Message: msg}, nil
 		}
 
-		_, err = c.MoveTask(id, body)
+		_, err = c.MoveTask(ctx, id, body)
 		if err != nil {
 			return nil, MoveTaskOutput{Success: false, Message: err.Error()}, err
 		}
@@ -291,7 +291,7 @@ func registerGTDTools(s *mcp.Server, c *todoist.Client) {
 				body["labels"] = item.Labels
 			}
 
-			task, err := c.CreateTask(body)
+			task, err := c.CreateTask(ctx, body)
 			if err != nil {
 				failed++
 				lines = append(lines, fmt.Sprintf("FAILED: %s — %s", item.Content, err.Error()))

--- a/internal/tools/labels.go
+++ b/internal/tools/labels.go
@@ -74,15 +74,14 @@ func registerLabelTools(s *mcp.Server, c *todoist.Client) {
 		Name:        "todoist_create_label",
 		Description: "Create a new personal label",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input CreateLabelInput) (*mcp.CallToolResult, CreateLabelOutput, error) {
-		body := map[string]any{"name": input.Name}
+		createReq := todoist.CreateLabelRequest{Name: input.Name}
 		if input.Color != "" {
-			body["color"] = input.Color
+			createReq.Color = todoist.Ptr(input.Color)
 		}
 		if input.IsFavorite {
-			body["is_favorite"] = true
+			createReq.IsFavorite = todoist.Ptr(true)
 		}
-
-		l, err := c.CreateLabel(ctx, body)
+		l, err := c.CreateLabel(ctx, createReq)
 		if err != nil {
 			return nil, CreateLabelOutput{Success: false, Message: err.Error()}, err
 		}
@@ -95,15 +94,14 @@ func registerLabelTools(s *mcp.Server, c *todoist.Client) {
 		Name:        "todoist_update_label",
 		Description: "Update an existing label",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input UpdateLabelInput) (*mcp.CallToolResult, UpdateLabelOutput, error) {
-		body := map[string]any{}
+		updateReq := todoist.UpdateLabelRequest{}
 		if input.Name != "" {
-			body["name"] = input.Name
+			updateReq.Name = todoist.Ptr(input.Name)
 		}
 		if input.Color != "" {
-			body["color"] = input.Color
+			updateReq.Color = todoist.Ptr(input.Color)
 		}
-
-		l, err := c.UpdateLabel(ctx, input.LabelID, body)
+		l, err := c.UpdateLabel(ctx, input.LabelID, updateReq)
 		if err != nil {
 			return nil, UpdateLabelOutput{Success: false, Message: err.Error()}, err
 		}

--- a/internal/tools/labels.go
+++ b/internal/tools/labels.go
@@ -76,10 +76,10 @@ func registerLabelTools(s *mcp.Server, c *todoist.Client) {
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input CreateLabelInput) (*mcp.CallToolResult, CreateLabelOutput, error) {
 		createReq := todoist.CreateLabelRequest{Name: input.Name}
 		if input.Color != "" {
-			createReq.Color = todoist.Ptr(input.Color)
+			createReq.Color = new(input.Color)
 		}
 		if input.IsFavorite {
-			createReq.IsFavorite = todoist.Ptr(true)
+			createReq.IsFavorite = new(true)
 		}
 		l, err := c.CreateLabel(ctx, createReq)
 		if err != nil {
@@ -96,10 +96,10 @@ func registerLabelTools(s *mcp.Server, c *todoist.Client) {
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input UpdateLabelInput) (*mcp.CallToolResult, UpdateLabelOutput, error) {
 		updateReq := todoist.UpdateLabelRequest{}
 		if input.Name != "" {
-			updateReq.Name = todoist.Ptr(input.Name)
+			updateReq.Name = new(input.Name)
 		}
 		if input.Color != "" {
-			updateReq.Color = todoist.Ptr(input.Color)
+			updateReq.Color = new(input.Color)
 		}
 		l, err := c.UpdateLabel(ctx, input.LabelID, updateReq)
 		if err != nil {

--- a/internal/tools/labels.go
+++ b/internal/tools/labels.go
@@ -48,7 +48,7 @@ func registerLabelTools(s *mcp.Server, c *todoist.Client) {
 		Name:        "todoist_get_labels",
 		Description: "List all personal labels",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input GetLabelsInput) (*mcp.CallToolResult, GetLabelsOutput, error) {
-		labels, err := c.GetLabels()
+		labels, err := c.GetLabels(ctx)
 		if err != nil {
 			return nil, GetLabelsOutput{}, err
 		}
@@ -82,7 +82,7 @@ func registerLabelTools(s *mcp.Server, c *todoist.Client) {
 			body["is_favorite"] = true
 		}
 
-		l, err := c.CreateLabel(body)
+		l, err := c.CreateLabel(ctx, body)
 		if err != nil {
 			return nil, CreateLabelOutput{Success: false, Message: err.Error()}, err
 		}
@@ -103,7 +103,7 @@ func registerLabelTools(s *mcp.Server, c *todoist.Client) {
 			body["color"] = input.Color
 		}
 
-		l, err := c.UpdateLabel(input.LabelID, body)
+		l, err := c.UpdateLabel(ctx, input.LabelID, body)
 		if err != nil {
 			return nil, UpdateLabelOutput{Success: false, Message: err.Error()}, err
 		}
@@ -116,7 +116,7 @@ func registerLabelTools(s *mcp.Server, c *todoist.Client) {
 		Name:        "todoist_delete_label",
 		Description: "Delete a label",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input DeleteLabelInput) (*mcp.CallToolResult, DeleteLabelOutput, error) {
-		if err := c.DeleteLabel(input.LabelID); err != nil {
+		if err := c.DeleteLabel(ctx, input.LabelID); err != nil {
 			return nil, DeleteLabelOutput{Success: false, Message: err.Error()}, err
 		}
 		msg := fmt.Sprintf("Successfully deleted label: %s", input.LabelID)

--- a/internal/tools/projects.go
+++ b/internal/tools/projects.go
@@ -121,21 +121,20 @@ func registerProjectTools(s *mcp.Server, c *todoist.Client) {
 		Name:        "todoist_create_project",
 		Description: "Create a new Todoist project",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input CreateProjectInput) (*mcp.CallToolResult, CreateProjectOutput, error) {
-		body := map[string]any{"name": input.Name}
+		createReq := todoist.CreateProjectRequest{Name: input.Name}
 		if input.ParentID != "" {
-			body["parent_id"] = input.ParentID
+			createReq.ParentID = todoist.Ptr(input.ParentID)
 		}
 		if input.Color != "" {
-			body["color"] = input.Color
+			createReq.Color = todoist.Ptr(input.Color)
 		}
 		if input.IsFavorite {
-			body["is_favorite"] = true
+			createReq.IsFavorite = todoist.Ptr(true)
 		}
 		if input.ViewStyle != "" {
-			body["view_style"] = input.ViewStyle
+			createReq.ViewStyle = todoist.Ptr(input.ViewStyle)
 		}
-
-		p, err := c.CreateProject(ctx, body)
+		p, err := c.CreateProject(ctx, createReq)
 		if err != nil {
 			return nil, CreateProjectOutput{Success: false, Message: err.Error()}, err
 		}
@@ -148,18 +147,17 @@ func registerProjectTools(s *mcp.Server, c *todoist.Client) {
 		Name:        "todoist_update_project",
 		Description: "Update an existing Todoist project",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input UpdateProjectInput) (*mcp.CallToolResult, UpdateProjectOutput, error) {
-		body := map[string]any{}
+		updateReq := todoist.UpdateProjectRequest{}
 		if input.Name != "" {
-			body["name"] = input.Name
+			updateReq.Name = todoist.Ptr(input.Name)
 		}
 		if input.Color != "" {
-			body["color"] = input.Color
+			updateReq.Color = todoist.Ptr(input.Color)
 		}
 		if input.IsFavorite != nil {
-			body["is_favorite"] = *input.IsFavorite
+			updateReq.IsFavorite = input.IsFavorite
 		}
-
-		p, err := c.UpdateProject(ctx, input.ProjectID, body)
+		p, err := c.UpdateProject(ctx, input.ProjectID, updateReq)
 		if err != nil {
 			return nil, UpdateProjectOutput{Success: false, Message: err.Error()}, err
 		}

--- a/internal/tools/projects.go
+++ b/internal/tools/projects.go
@@ -123,16 +123,16 @@ func registerProjectTools(s *mcp.Server, c *todoist.Client) {
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input CreateProjectInput) (*mcp.CallToolResult, CreateProjectOutput, error) {
 		createReq := todoist.CreateProjectRequest{Name: input.Name}
 		if input.ParentID != "" {
-			createReq.ParentID = todoist.Ptr(input.ParentID)
+			createReq.ParentID = new(input.ParentID)
 		}
 		if input.Color != "" {
-			createReq.Color = todoist.Ptr(input.Color)
+			createReq.Color = new(input.Color)
 		}
 		if input.IsFavorite {
-			createReq.IsFavorite = todoist.Ptr(true)
+			createReq.IsFavorite = new(true)
 		}
 		if input.ViewStyle != "" {
-			createReq.ViewStyle = todoist.Ptr(input.ViewStyle)
+			createReq.ViewStyle = new(input.ViewStyle)
 		}
 		p, err := c.CreateProject(ctx, createReq)
 		if err != nil {
@@ -149,10 +149,10 @@ func registerProjectTools(s *mcp.Server, c *todoist.Client) {
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input UpdateProjectInput) (*mcp.CallToolResult, UpdateProjectOutput, error) {
 		updateReq := todoist.UpdateProjectRequest{}
 		if input.Name != "" {
-			updateReq.Name = todoist.Ptr(input.Name)
+			updateReq.Name = new(input.Name)
 		}
 		if input.Color != "" {
-			updateReq.Color = todoist.Ptr(input.Color)
+			updateReq.Color = new(input.Color)
 		}
 		if input.IsFavorite != nil {
 			updateReq.IsFavorite = input.IsFavorite

--- a/internal/tools/projects.go
+++ b/internal/tools/projects.go
@@ -75,7 +75,7 @@ func registerProjectTools(s *mcp.Server, c *todoist.Client) {
 		Name:        "todoist_get_projects",
 		Description: "List all Todoist projects",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input GetProjectsInput) (*mcp.CallToolResult, GetProjectsOutput, error) {
-		projects, err := c.GetProjects()
+		projects, err := c.GetProjects(ctx)
 		if err != nil {
 			return nil, GetProjectsOutput{}, err
 		}
@@ -104,7 +104,7 @@ func registerProjectTools(s *mcp.Server, c *todoist.Client) {
 		Name:        "todoist_get_project",
 		Description: "Get a single Todoist project by ID",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input GetProjectInput) (*mcp.CallToolResult, GetProjectOutput, error) {
-		p, err := c.GetProject(input.ProjectID)
+		p, err := c.GetProject(ctx, input.ProjectID)
 		if err != nil {
 			return nil, GetProjectOutput{}, err
 		}
@@ -135,7 +135,7 @@ func registerProjectTools(s *mcp.Server, c *todoist.Client) {
 			body["view_style"] = input.ViewStyle
 		}
 
-		p, err := c.CreateProject(body)
+		p, err := c.CreateProject(ctx, body)
 		if err != nil {
 			return nil, CreateProjectOutput{Success: false, Message: err.Error()}, err
 		}
@@ -159,7 +159,7 @@ func registerProjectTools(s *mcp.Server, c *todoist.Client) {
 			body["is_favorite"] = *input.IsFavorite
 		}
 
-		p, err := c.UpdateProject(input.ProjectID, body)
+		p, err := c.UpdateProject(ctx, input.ProjectID, body)
 		if err != nil {
 			return nil, UpdateProjectOutput{Success: false, Message: err.Error()}, err
 		}
@@ -172,7 +172,7 @@ func registerProjectTools(s *mcp.Server, c *todoist.Client) {
 		Name:        "todoist_delete_project",
 		Description: "Delete a Todoist project",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input DeleteProjectInput) (*mcp.CallToolResult, DeleteProjectOutput, error) {
-		if err := c.DeleteProject(input.ProjectID); err != nil {
+		if err := c.DeleteProject(ctx, input.ProjectID); err != nil {
 			return nil, DeleteProjectOutput{Success: false, Message: err.Error()}, err
 		}
 		msg := fmt.Sprintf("Successfully deleted project: %s", input.ProjectID)
@@ -183,7 +183,7 @@ func registerProjectTools(s *mcp.Server, c *todoist.Client) {
 		Name:        "todoist_archive_project",
 		Description: "Archive a Todoist project",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input ArchiveProjectInput) (*mcp.CallToolResult, ArchiveProjectOutput, error) {
-		if err := c.ArchiveProject(input.ProjectID); err != nil {
+		if err := c.ArchiveProject(ctx, input.ProjectID); err != nil {
 			return nil, ArchiveProjectOutput{Success: false, Message: err.Error()}, err
 		}
 		msg := fmt.Sprintf("Successfully archived project: %s", input.ProjectID)
@@ -194,7 +194,7 @@ func registerProjectTools(s *mcp.Server, c *todoist.Client) {
 		Name:        "todoist_unarchive_project",
 		Description: "Unarchive a Todoist project",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input UnarchiveProjectInput) (*mcp.CallToolResult, UnarchiveProjectOutput, error) {
-		if err := c.UnarchiveProject(input.ProjectID); err != nil {
+		if err := c.UnarchiveProject(ctx, input.ProjectID); err != nil {
 			return nil, UnarchiveProjectOutput{Success: false, Message: err.Error()}, err
 		}
 		msg := fmt.Sprintf("Successfully unarchived project: %s", input.ProjectID)

--- a/internal/tools/sections.go
+++ b/internal/tools/sections.go
@@ -49,7 +49,7 @@ func registerSectionTools(s *mcp.Server, c *todoist.Client) {
 		Name:        "todoist_get_sections",
 		Description: "List sections, optionally filtered by project",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input GetSectionsInput) (*mcp.CallToolResult, GetSectionsOutput, error) {
-		sections, err := c.GetSections(input.ProjectID)
+		sections, err := c.GetSections(ctx, input.ProjectID)
 		if err != nil {
 			return nil, GetSectionsOutput{}, err
 		}
@@ -79,7 +79,7 @@ func registerSectionTools(s *mcp.Server, c *todoist.Client) {
 			body["section_order"] = input.Order
 		}
 
-		sec, err := c.CreateSection(body)
+		sec, err := c.CreateSection(ctx, body)
 		if err != nil {
 			return nil, CreateSectionOutput{Success: false, Message: err.Error()}, err
 		}
@@ -93,7 +93,7 @@ func registerSectionTools(s *mcp.Server, c *todoist.Client) {
 		Description: "Update an existing section name",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input UpdateSectionInput) (*mcp.CallToolResult, UpdateSectionOutput, error) {
 		body := map[string]any{"name": input.Name}
-		sec, err := c.UpdateSection(input.SectionID, body)
+		sec, err := c.UpdateSection(ctx, input.SectionID, body)
 		if err != nil {
 			return nil, UpdateSectionOutput{Success: false, Message: err.Error()}, err
 		}
@@ -106,7 +106,7 @@ func registerSectionTools(s *mcp.Server, c *todoist.Client) {
 		Name:        "todoist_delete_section",
 		Description: "Delete a section from a Todoist project",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input DeleteSectionInput) (*mcp.CallToolResult, DeleteSectionOutput, error) {
-		if err := c.DeleteSection(input.SectionID); err != nil {
+		if err := c.DeleteSection(ctx, input.SectionID); err != nil {
 			return nil, DeleteSectionOutput{Success: false, Message: err.Error()}, err
 		}
 		msg := fmt.Sprintf("Successfully deleted section: %s", input.SectionID)

--- a/internal/tools/sections.go
+++ b/internal/tools/sections.go
@@ -73,7 +73,7 @@ func registerSectionTools(s *mcp.Server, c *todoist.Client) {
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input CreateSectionInput) (*mcp.CallToolResult, CreateSectionOutput, error) {
 		createReq := todoist.CreateSectionRequest{Name: input.Name, ProjectID: input.ProjectID}
 		if input.Order > 0 {
-			createReq.SectionOrder = todoist.Ptr(input.Order)
+			createReq.SectionOrder = new(input.Order)
 		}
 		sec, err := c.CreateSection(ctx, createReq)
 		if err != nil {

--- a/internal/tools/sections.go
+++ b/internal/tools/sections.go
@@ -71,15 +71,11 @@ func registerSectionTools(s *mcp.Server, c *todoist.Client) {
 		Name:        "todoist_create_section",
 		Description: "Create a new section in a Todoist project",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input CreateSectionInput) (*mcp.CallToolResult, CreateSectionOutput, error) {
-		body := map[string]any{
-			"name":       input.Name,
-			"project_id": input.ProjectID,
-		}
+		createReq := todoist.CreateSectionRequest{Name: input.Name, ProjectID: input.ProjectID}
 		if input.Order > 0 {
-			body["section_order"] = input.Order
+			createReq.SectionOrder = todoist.Ptr(input.Order)
 		}
-
-		sec, err := c.CreateSection(ctx, body)
+		sec, err := c.CreateSection(ctx, createReq)
 		if err != nil {
 			return nil, CreateSectionOutput{Success: false, Message: err.Error()}, err
 		}
@@ -92,8 +88,7 @@ func registerSectionTools(s *mcp.Server, c *todoist.Client) {
 		Name:        "todoist_update_section",
 		Description: "Update an existing section name",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input UpdateSectionInput) (*mcp.CallToolResult, UpdateSectionOutput, error) {
-		body := map[string]any{"name": input.Name}
-		sec, err := c.UpdateSection(ctx, input.SectionID, body)
+		sec, err := c.UpdateSection(ctx, input.SectionID, todoist.UpdateSectionRequest{Name: input.Name})
 		if err != nil {
 			return nil, UpdateSectionOutput{Success: false, Message: err.Error()}, err
 		}

--- a/internal/tools/tasks.go
+++ b/internal/tools/tasks.go
@@ -121,33 +121,33 @@ func registerTaskTools(s *mcp.Server, c *todoist.Client) {
 		Name:        "todoist_create_task",
 		Description: "Create a new task in Todoist with optional description, due date, priority, project, section, labels, and assignee",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input CreateTaskInput) (*mcp.CallToolResult, CreateTaskOutput, error) {
-		body := map[string]any{"content": input.Content}
+		createReq := todoist.CreateTaskRequest{Content: input.Content}
 		if input.Description != "" {
-			body["description"] = input.Description
+			createReq.Description = todoist.Ptr(input.Description)
 		}
 		if input.DueString != "" {
-			body["due_string"] = input.DueString
+			createReq.DueString = todoist.Ptr(input.DueString)
 		}
 		if input.Priority > 0 && input.Priority <= 4 {
-			body["priority"] = input.Priority
+			createReq.Priority = todoist.Ptr(input.Priority)
 		}
 		if input.ProjectID != "" {
-			body["project_id"] = input.ProjectID
+			createReq.ProjectID = todoist.Ptr(input.ProjectID)
 		}
 		if input.SectionID != "" {
-			body["section_id"] = input.SectionID
+			createReq.SectionID = todoist.Ptr(input.SectionID)
 		}
 		if input.ParentID != "" {
-			body["parent_id"] = input.ParentID
+			createReq.ParentID = todoist.Ptr(input.ParentID)
 		}
 		if len(input.Labels) > 0 {
-			body["labels"] = input.Labels
+			createReq.Labels = input.Labels
 		}
 		if input.AssigneeID != "" {
-			body["assignee_id"] = input.AssigneeID
+			createReq.AssigneeID = todoist.Ptr(input.AssigneeID)
 		}
 
-		task, err := c.CreateTask(ctx, body)
+		task, err := c.CreateTask(ctx, createReq)
 		if err != nil {
 			return nil, CreateTaskOutput{Success: false, Message: err.Error()}, err
 		}
@@ -238,30 +238,30 @@ func registerTaskTools(s *mcp.Server, c *todoist.Client) {
 			return textResult(msg, true), UpdateTaskOutput{Success: false, Message: msg}, nil
 		}
 
-		body := map[string]any{}
+		updateReq := todoist.UpdateTaskRequest{}
 		if input.Content != "" {
-			body["content"] = input.Content
+			updateReq.Content = todoist.Ptr(input.Content)
 		}
 		if input.Description != "" {
-			body["description"] = input.Description
+			updateReq.Description = todoist.Ptr(input.Description)
 		}
 		if input.DueString != "" {
-			body["due_string"] = input.DueString
+			updateReq.DueString = todoist.Ptr(input.DueString)
 		}
 		if input.Priority > 0 && input.Priority <= 4 {
-			body["priority"] = input.Priority
+			updateReq.Priority = todoist.Ptr(input.Priority)
 		}
 		if len(input.Labels) > 0 {
-			body["labels"] = input.Labels
+			updateReq.Labels = todoist.Ptr(input.Labels)
 		}
 		if input.AssigneeID != "" {
-			body["assignee_id"] = input.AssigneeID
+			updateReq.AssigneeID = todoist.Ptr(input.AssigneeID)
 		}
 		if input.DeadlineDate != "" {
-			body["deadline_date"] = input.DeadlineDate
+			updateReq.DeadlineDate = todoist.Ptr(input.DeadlineDate)
 		}
 
-		updated, err := c.UpdateTask(ctx, id, body)
+		updated, err := c.UpdateTask(ctx, id, updateReq)
 		if err != nil {
 			return nil, UpdateTaskOutput{Success: false, Message: err.Error()}, err
 		}

--- a/internal/tools/tasks.go
+++ b/internal/tools/tasks.go
@@ -123,28 +123,28 @@ func registerTaskTools(s *mcp.Server, c *todoist.Client) {
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input CreateTaskInput) (*mcp.CallToolResult, CreateTaskOutput, error) {
 		createReq := todoist.CreateTaskRequest{Content: input.Content}
 		if input.Description != "" {
-			createReq.Description = todoist.Ptr(input.Description)
+			createReq.Description = new(input.Description)
 		}
 		if input.DueString != "" {
-			createReq.DueString = todoist.Ptr(input.DueString)
+			createReq.DueString = new(input.DueString)
 		}
 		if input.Priority > 0 && input.Priority <= 4 {
-			createReq.Priority = todoist.Ptr(input.Priority)
+			createReq.Priority = new(input.Priority)
 		}
 		if input.ProjectID != "" {
-			createReq.ProjectID = todoist.Ptr(input.ProjectID)
+			createReq.ProjectID = new(input.ProjectID)
 		}
 		if input.SectionID != "" {
-			createReq.SectionID = todoist.Ptr(input.SectionID)
+			createReq.SectionID = new(input.SectionID)
 		}
 		if input.ParentID != "" {
-			createReq.ParentID = todoist.Ptr(input.ParentID)
+			createReq.ParentID = new(input.ParentID)
 		}
 		if len(input.Labels) > 0 {
 			createReq.Labels = input.Labels
 		}
 		if input.AssigneeID != "" {
-			createReq.AssigneeID = todoist.Ptr(input.AssigneeID)
+			createReq.AssigneeID = new(input.AssigneeID)
 		}
 
 		task, err := c.CreateTask(ctx, createReq)
@@ -240,25 +240,25 @@ func registerTaskTools(s *mcp.Server, c *todoist.Client) {
 
 		updateReq := todoist.UpdateTaskRequest{}
 		if input.Content != "" {
-			updateReq.Content = todoist.Ptr(input.Content)
+			updateReq.Content = new(input.Content)
 		}
 		if input.Description != "" {
-			updateReq.Description = todoist.Ptr(input.Description)
+			updateReq.Description = new(input.Description)
 		}
 		if input.DueString != "" {
-			updateReq.DueString = todoist.Ptr(input.DueString)
+			updateReq.DueString = new(input.DueString)
 		}
 		if input.Priority > 0 && input.Priority <= 4 {
-			updateReq.Priority = todoist.Ptr(input.Priority)
+			updateReq.Priority = new(input.Priority)
 		}
 		if len(input.Labels) > 0 {
-			updateReq.Labels = todoist.Ptr(input.Labels)
+			updateReq.Labels = new(input.Labels)
 		}
 		if input.AssigneeID != "" {
-			updateReq.AssigneeID = todoist.Ptr(input.AssigneeID)
+			updateReq.AssigneeID = new(input.AssigneeID)
 		}
 		if input.DeadlineDate != "" {
-			updateReq.DeadlineDate = todoist.Ptr(input.DeadlineDate)
+			updateReq.DeadlineDate = new(input.DeadlineDate)
 		}
 
 		updated, err := c.UpdateTask(ctx, id, updateReq)

--- a/internal/tools/tasks.go
+++ b/internal/tools/tasks.go
@@ -90,14 +90,14 @@ type ReopenTaskOutput struct {
 
 // --- helpers ---
 
-func resolveTaskID(c *todoist.Client, id, name string) (string, string, error) {
+func resolveTaskID(ctx context.Context, c *todoist.Client, id, name string) (string, string, error) {
 	if id != "" {
 		return id, "", nil
 	}
 	if name == "" {
 		return "", "", fmt.Errorf("either task_id or task_name is required")
 	}
-	task, err := c.FindTaskByName(name)
+	task, err := c.FindTaskByName(ctx, name)
 	if err != nil {
 		return "", "", err
 	}
@@ -147,7 +147,7 @@ func registerTaskTools(s *mcp.Server, c *todoist.Client) {
 			body["assignee_id"] = input.AssigneeID
 		}
 
-		task, err := c.CreateTask(body)
+		task, err := c.CreateTask(ctx, body)
 		if err != nil {
 			return nil, CreateTaskOutput{Success: false, Message: err.Error()}, err
 		}
@@ -173,9 +173,9 @@ func registerTaskTools(s *mcp.Server, c *todoist.Client) {
 		var tasks []models.Task
 		var err error
 		if input.Filter != "" {
-			tasks, err = c.GetTasksByFilter(input.Filter)
+			tasks, err = c.GetTasksByFilter(ctx, input.Filter)
 		} else {
-			tasks, err = c.GetTasks(input.ProjectID)
+			tasks, err = c.GetTasks(ctx, input.ProjectID)
 		}
 		if err != nil {
 			return nil, GetTasksOutput{}, err
@@ -229,7 +229,7 @@ func registerTaskTools(s *mcp.Server, c *todoist.Client) {
 		Name:        "todoist_update_task",
 		Description: "Update an existing task in Todoist by task_id or by searching by name",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input UpdateTaskInput) (*mcp.CallToolResult, UpdateTaskOutput, error) {
-		id, originalName, err := resolveTaskID(c, input.TaskID, input.TaskName)
+		id, originalName, err := resolveTaskID(ctx, c, input.TaskID, input.TaskName)
 		if err != nil {
 			return nil, UpdateTaskOutput{Success: false, Message: err.Error()}, err
 		}
@@ -261,7 +261,7 @@ func registerTaskTools(s *mcp.Server, c *todoist.Client) {
 			body["deadline_date"] = input.DeadlineDate
 		}
 
-		updated, err := c.UpdateTask(id, body)
+		updated, err := c.UpdateTask(ctx, id, body)
 		if err != nil {
 			return nil, UpdateTaskOutput{Success: false, Message: err.Error()}, err
 		}
@@ -288,7 +288,7 @@ func registerTaskTools(s *mcp.Server, c *todoist.Client) {
 		Name:        "todoist_delete_task",
 		Description: "Delete a task from Todoist by task_id or by searching by name",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input DeleteTaskInput) (*mcp.CallToolResult, DeleteTaskOutput, error) {
-		id, originalName, err := resolveTaskID(c, input.TaskID, input.TaskName)
+		id, originalName, err := resolveTaskID(ctx, c, input.TaskID, input.TaskName)
 		if err != nil {
 			return nil, DeleteTaskOutput{Success: false, Message: err.Error()}, err
 		}
@@ -297,7 +297,7 @@ func registerTaskTools(s *mcp.Server, c *todoist.Client) {
 			return textResult(msg, true), DeleteTaskOutput{Success: false, Message: msg}, nil
 		}
 
-		if err := c.DeleteTask(id); err != nil {
+		if err := c.DeleteTask(ctx, id); err != nil {
 			return nil, DeleteTaskOutput{Success: false, Message: err.Error()}, err
 		}
 
@@ -313,7 +313,7 @@ func registerTaskTools(s *mcp.Server, c *todoist.Client) {
 		Name:        "todoist_complete_task",
 		Description: "Mark a task as complete by task_id or by searching by name",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input CompleteTaskInput) (*mcp.CallToolResult, CompleteTaskOutput, error) {
-		id, originalName, err := resolveTaskID(c, input.TaskID, input.TaskName)
+		id, originalName, err := resolveTaskID(ctx, c, input.TaskID, input.TaskName)
 		if err != nil {
 			return nil, CompleteTaskOutput{Success: false, Message: err.Error()}, err
 		}
@@ -322,7 +322,7 @@ func registerTaskTools(s *mcp.Server, c *todoist.Client) {
 			return textResult(msg, true), CompleteTaskOutput{Success: false, Message: msg}, nil
 		}
 
-		if err := c.CloseTask(id); err != nil {
+		if err := c.CloseTask(ctx, id); err != nil {
 			return nil, CompleteTaskOutput{Success: false, Message: err.Error()}, err
 		}
 
@@ -338,7 +338,7 @@ func registerTaskTools(s *mcp.Server, c *todoist.Client) {
 		Name:        "todoist_reopen_task",
 		Description: "Reopen a completed task by task_id or by searching by name",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input ReopenTaskInput) (*mcp.CallToolResult, ReopenTaskOutput, error) {
-		id, originalName, err := resolveTaskID(c, input.TaskID, input.TaskName)
+		id, originalName, err := resolveTaskID(ctx, c, input.TaskID, input.TaskName)
 		if err != nil {
 			return nil, ReopenTaskOutput{Success: false, Message: err.Error()}, err
 		}
@@ -347,7 +347,7 @@ func registerTaskTools(s *mcp.Server, c *todoist.Client) {
 			return textResult(msg, true), ReopenTaskOutput{Success: false, Message: msg}, nil
 		}
 
-		if err := c.ReopenTask(id); err != nil {
+		if err := c.ReopenTask(ctx, id); err != nil {
 			return nil, ReopenTaskOutput{Success: false, Message: err.Error()}, err
 		}
 


### PR DESCRIPTION
Stage 2 of the tech debt refactor (spec: docs/superpowers/specs/2026-07-14-tech-debt-refactor-design.md).

- Every Todoist client method now takes ctx as its first parameter; do() uses http.NewRequestWithContext, so MCP cancellation propagates to HTTP calls.
- All map[string]any request bodies replaced with typed request structs (CreateTaskRequest, UpdateTaskRequest, MoveTaskRequest, plus project/section/label/comment equivalents). Nil-pointer omitempty fields marshal identically to the old omitted map keys, so the wire format is unchanged.
- Deviation from the plan doc: the planned todoist.Ptr helper is replaced by Go 1.26's built-in new(expr), because the CI go fix modernizer gate rejects the helper pattern.

No behavior change; all existing test assertions preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015j22Jr9L3mzY3wNohfvWcu