### PR TITLE
refactor: stage 3 handler dedup

### DIFF
--- a/internal/tools/comments.go
+++ b/internal/tools/comments.go
@@ -13,51 +13,32 @@ type GetCommentsInput struct {
 	TaskID    string `json:"task_id,omitempty" jsonschema:"Get comments for a task (provide task_id or project_id)"`
 	ProjectID string `json:"project_id,omitempty" jsonschema:"Get comments for a project (provide task_id or project_id)"`
 }
-type GetCommentsOutput struct {
-	Success bool   `json:"success"`
-	Message string `json:"message"`
-}
-
 type CreateCommentInput struct {
 	Content   string `json:"content" jsonschema:"Comment text content"`
 	TaskID    string `json:"task_id,omitempty" jsonschema:"Task ID to comment on (provide task_id or project_id)"`
 	ProjectID string `json:"project_id,omitempty" jsonschema:"Project ID to comment on (provide task_id or project_id)"`
 }
-type CreateCommentOutput struct {
-	Success bool   `json:"success"`
-	Message string `json:"message"`
-}
-
 type UpdateCommentInput struct {
 	CommentID string `json:"comment_id" jsonschema:"The comment ID to update"`
 	Content   string `json:"content" jsonschema:"New comment text content"`
 }
-type UpdateCommentOutput struct {
-	Success bool   `json:"success"`
-	Message string `json:"message"`
-}
-
 type DeleteCommentInput struct {
 	CommentID string `json:"comment_id" jsonschema:"The comment ID to delete"`
-}
-type DeleteCommentOutput struct {
-	Success bool   `json:"success"`
-	Message string `json:"message"`
 }
 
 func registerCommentTools(s *mcp.Server, c *todoist.Client) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "todoist_get_comments",
 		Description: "List comments for a task or project",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, input GetCommentsInput) (*mcp.CallToolResult, GetCommentsOutput, error) {
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input GetCommentsInput) (*mcp.CallToolResult, ActionOutput, error) {
 		comments, err := c.GetComments(ctx, input.TaskID, input.ProjectID)
 		if err != nil {
-			return nil, GetCommentsOutput{}, err
+			return nil, ActionOutput{}, err
 		}
 
 		if len(comments) == 0 {
 			msg := "No comments found"
-			return textResult(msg, false), GetCommentsOutput{Success: true, Message: msg}, nil
+			return textResult(msg, false), ActionOutput{Success: true, Message: msg}, nil
 		}
 
 		var lines []string
@@ -65,13 +46,13 @@ func registerCommentTools(s *mcp.Server, c *todoist.Client) {
 			lines = append(lines, fmt.Sprintf("- [%s] %s (ID: %s)", cm.PostedAt.Format("2006-01-02 15:04"), cm.Content, cm.ID))
 		}
 		msg := strings.Join(lines, "\n")
-		return textResult(msg, false), GetCommentsOutput{Success: true, Message: msg}, nil
+		return textResult(msg, false), ActionOutput{Success: true, Message: msg}, nil
 	})
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "todoist_create_comment",
 		Description: "Add a comment to a task or project",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, input CreateCommentInput) (*mcp.CallToolResult, CreateCommentOutput, error) {
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input CreateCommentInput) (*mcp.CallToolResult, ActionOutput, error) {
 		createReq := todoist.CreateCommentRequest{Content: input.Content}
 		if input.TaskID != "" {
 			createReq.TaskID = new(input.TaskID)
@@ -81,34 +62,34 @@ func registerCommentTools(s *mcp.Server, c *todoist.Client) {
 		}
 		cm, err := c.CreateComment(ctx, createReq)
 		if err != nil {
-			return nil, CreateCommentOutput{Success: false, Message: err.Error()}, err
+			return nil, ActionOutput{Success: false, Message: err.Error()}, err
 		}
 
 		msg := fmt.Sprintf("Comment created (ID: %s): %s", cm.ID, cm.Content)
-		return textResult(msg, false), CreateCommentOutput{Success: true, Message: msg}, nil
+		return textResult(msg, false), ActionOutput{Success: true, Message: msg}, nil
 	})
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "todoist_update_comment",
 		Description: "Update an existing comment",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, input UpdateCommentInput) (*mcp.CallToolResult, UpdateCommentOutput, error) {
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input UpdateCommentInput) (*mcp.CallToolResult, ActionOutput, error) {
 		cm, err := c.UpdateComment(ctx, input.CommentID, todoist.UpdateCommentRequest{Content: input.Content})
 		if err != nil {
-			return nil, UpdateCommentOutput{Success: false, Message: err.Error()}, err
+			return nil, ActionOutput{Success: false, Message: err.Error()}, err
 		}
 
 		msg := fmt.Sprintf("Comment updated (ID: %s): %s", cm.ID, cm.Content)
-		return textResult(msg, false), UpdateCommentOutput{Success: true, Message: msg}, nil
+		return textResult(msg, false), ActionOutput{Success: true, Message: msg}, nil
 	})
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "todoist_delete_comment",
 		Description: "Delete a comment",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, input DeleteCommentInput) (*mcp.CallToolResult, DeleteCommentOutput, error) {
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input DeleteCommentInput) (*mcp.CallToolResult, ActionOutput, error) {
 		if err := c.DeleteComment(ctx, input.CommentID); err != nil {
-			return nil, DeleteCommentOutput{Success: false, Message: err.Error()}, err
+			return nil, ActionOutput{Success: false, Message: err.Error()}, err
 		}
 		msg := fmt.Sprintf("Successfully deleted comment: %s", input.CommentID)
-		return textResult(msg, false), DeleteCommentOutput{Success: true, Message: msg}, nil
+		return textResult(msg, false), ActionOutput{Success: true, Message: msg}, nil
 	})
 }

--- a/internal/tools/gtd.go
+++ b/internal/tools/gtd.go
@@ -14,18 +14,10 @@ import (
 // --- Inbox Review ---
 
 type InboxReviewInput struct{}
-type InboxReviewOutput struct {
-	Success bool   `json:"success"`
-	Message string `json:"message"`
-}
 
 // --- Weekly Review ---
 
 type WeeklyReviewInput struct{}
-type WeeklyReviewOutput struct {
-	Success bool   `json:"success"`
-	Message string `json:"message"`
-}
 
 // --- Move Task ---
 
@@ -35,10 +27,6 @@ type MoveTaskInput struct {
 	ProjectID string `json:"project_id,omitempty" jsonschema:"Destination project ID. Set exactly one of project_id, section_id, parent_id."`
 	SectionID string `json:"section_id,omitempty" jsonschema:"Destination section ID. Set exactly one of project_id, section_id, parent_id."`
 	ParentID  string `json:"parent_id,omitempty" jsonschema:"Destination parent task ID. Set exactly one of project_id, section_id, parent_id."`
-}
-type MoveTaskOutput struct {
-	Success bool   `json:"success"`
-	Message string `json:"message"`
 }
 
 // --- Bulk Create Tasks ---
@@ -56,21 +44,17 @@ type BulkTaskItem struct {
 type BulkCreateTasksInput struct {
 	Tasks []BulkTaskItem `json:"tasks" jsonschema:"Array of tasks to create"`
 }
-type BulkCreateTasksOutput struct {
-	Success bool   `json:"success"`
-	Message string `json:"message"`
-}
 
 func registerGTDTools(s *mcp.Server, c *todoist.Client) {
 	// --- todoist_inbox_review ---
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "todoist_inbox_review",
 		Description: "Get all inbox tasks grouped by age (today, this week, older) for GTD inbox processing",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, input InboxReviewInput) (*mcp.CallToolResult, InboxReviewOutput, error) {
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input InboxReviewInput) (*mcp.CallToolResult, ActionOutput, error) {
 		// Find inbox project.
 		projects, err := c.GetProjects(ctx)
 		if err != nil {
-			return nil, InboxReviewOutput{}, err
+			return nil, ActionOutput{}, err
 		}
 
 		var inboxID string
@@ -82,17 +66,17 @@ func registerGTDTools(s *mcp.Server, c *todoist.Client) {
 		}
 		if inboxID == "" {
 			msg := "Could not find inbox project"
-			return textResult(msg, true), InboxReviewOutput{Success: false, Message: msg}, nil
+			return textResult(msg, true), ActionOutput{Success: false, Message: msg}, nil
 		}
 
 		tasks, err := c.GetTasks(ctx, inboxID)
 		if err != nil {
-			return nil, InboxReviewOutput{}, err
+			return nil, ActionOutput{}, err
 		}
 
 		if len(tasks) == 0 {
 			msg := "Inbox is empty! Nothing to process."
-			return textResult(msg, false), InboxReviewOutput{Success: true, Message: msg}, nil
+			return textResult(msg, false), ActionOutput{Success: true, Message: msg}, nil
 		}
 
 		now := time.Now()
@@ -134,22 +118,22 @@ func registerGTDTools(s *mcp.Server, c *todoist.Client) {
 		writeGroup("Older", olderTasks)
 
 		msg := sb.String()
-		return textResult(msg, false), InboxReviewOutput{Success: true, Message: msg}, nil
+		return textResult(msg, false), ActionOutput{Success: true, Message: msg}, nil
 	})
 
 	// --- todoist_weekly_review ---
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "todoist_weekly_review",
 		Description: "Comprehensive weekly review: projects with task counts, overdue tasks, tasks with no due date",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, input WeeklyReviewInput) (*mcp.CallToolResult, WeeklyReviewOutput, error) {
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input WeeklyReviewInput) (*mcp.CallToolResult, ActionOutput, error) {
 		projects, err := c.GetProjects(ctx)
 		if err != nil {
-			return nil, WeeklyReviewOutput{}, err
+			return nil, ActionOutput{}, err
 		}
 
 		allTasks, err := c.GetTasks(ctx, "")
 		if err != nil {
-			return nil, WeeklyReviewOutput{}, err
+			return nil, ActionOutput{}, err
 		}
 
 		// Count tasks per project.
@@ -205,21 +189,21 @@ func registerGTDTools(s *mcp.Server, c *todoist.Client) {
 		}
 
 		msg := sb.String()
-		return textResult(msg, false), WeeklyReviewOutput{Success: true, Message: msg}, nil
+		return textResult(msg, false), ActionOutput{Success: true, Message: msg}, nil
 	})
 
 	// --- todoist_move_task ---
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "todoist_move_task",
 		Description: "Move a task to a different project, section, or parent. Set exactly one of project_id, section_id, parent_id.",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, input MoveTaskInput) (*mcp.CallToolResult, MoveTaskOutput, error) {
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input MoveTaskInput) (*mcp.CallToolResult, ActionOutput, error) {
 		id, originalName, err := resolveTaskID(ctx, c, input.TaskID, input.TaskName)
 		if err != nil {
-			return nil, MoveTaskOutput{Success: false, Message: err.Error()}, err
+			return nil, ActionOutput{Success: false, Message: err.Error()}, err
 		}
 		if id == "" {
 			msg := fmt.Sprintf("Could not find a task matching \"%s\"", input.TaskName)
-			return textResult(msg, true), MoveTaskOutput{Success: false, Message: msg}, nil
+			return textResult(msg, true), ActionOutput{Success: false, Message: msg}, nil
 		}
 
 		moveReq := todoist.MoveTaskRequest{}
@@ -238,12 +222,12 @@ func registerGTDTools(s *mcp.Server, c *todoist.Client) {
 		}
 		if dests != 1 {
 			msg := "exactly one of project_id, section_id, parent_id must be set"
-			return textResult(msg, true), MoveTaskOutput{Success: false, Message: msg}, nil
+			return textResult(msg, true), ActionOutput{Success: false, Message: msg}, nil
 		}
 
 		_, err = c.MoveTask(ctx, id, moveReq)
 		if err != nil {
-			return nil, MoveTaskOutput{Success: false, Message: err.Error()}, err
+			return nil, ActionOutput{Success: false, Message: err.Error()}, err
 		}
 
 		label := originalName
@@ -259,14 +243,14 @@ func registerGTDTools(s *mcp.Server, c *todoist.Client) {
 		case input.ParentID != "":
 			msg += fmt.Sprintf(" under parent %s", input.ParentID)
 		}
-		return textResult(msg, false), MoveTaskOutput{Success: true, Message: msg}, nil
+		return textResult(msg, false), ActionOutput{Success: true, Message: msg}, nil
 	})
 
 	// --- todoist_bulk_create_tasks ---
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "todoist_bulk_create_tasks",
 		Description: "Create multiple tasks at once. Useful for batch processing from knowledge capture or project planning",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, input BulkCreateTasksInput) (*mcp.CallToolResult, BulkCreateTasksOutput, error) {
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input BulkCreateTasksInput) (*mcp.CallToolResult, ActionOutput, error) {
 		var created, failed int
 		var lines []string
 
@@ -303,6 +287,6 @@ func registerGTDTools(s *mcp.Server, c *todoist.Client) {
 
 		msg := fmt.Sprintf("Bulk create: %d created, %d failed\n\n%s", created, failed, strings.Join(lines, "\n"))
 		success := failed == 0
-		return textResult(msg, !success), BulkCreateTasksOutput{Success: success, Message: msg}, nil
+		return textResult(msg, !success), ActionOutput{Success: success, Message: msg}, nil
 	})
 }

--- a/internal/tools/gtd.go
+++ b/internal/tools/gtd.go
@@ -197,7 +197,7 @@ func registerGTDTools(s *mcp.Server, c *todoist.Client) {
 		Name:        "todoist_move_task",
 		Description: "Move a task to a different project, section, or parent. Set exactly one of project_id, section_id, parent_id.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input MoveTaskInput) (*mcp.CallToolResult, ActionOutput, error) {
-		id, originalName, err := resolveTaskID(ctx, c, input.TaskID, input.TaskName)
+		id, label, err := resolveTask(ctx, c, input.TaskID, input.TaskName)
 		if err != nil {
 			return nil, ActionOutput{Success: false, Message: err.Error()}, err
 		}
@@ -230,10 +230,6 @@ func registerGTDTools(s *mcp.Server, c *todoist.Client) {
 			return nil, ActionOutput{Success: false, Message: err.Error()}, err
 		}
 
-		label := originalName
-		if label == "" {
-			label = id
-		}
 		msg := fmt.Sprintf("Successfully moved task \"%s\"", label)
 		switch {
 		case input.ProjectID != "":

--- a/internal/tools/labels.go
+++ b/internal/tools/labels.go
@@ -10,52 +10,33 @@ import (
 )
 
 type GetLabelsInput struct{}
-type GetLabelsOutput struct {
-	Success bool   `json:"success"`
-	Message string `json:"message"`
-}
-
 type CreateLabelInput struct {
 	Name       string `json:"name" jsonschema:"Name of the label"`
 	Color      string `json:"color,omitempty" jsonschema:"Color of the label (optional)"`
 	IsFavorite bool   `json:"is_favorite,omitempty" jsonschema:"Whether the label is a favorite (optional)"`
 }
-type CreateLabelOutput struct {
-	Success bool   `json:"success"`
-	Message string `json:"message"`
-}
-
 type UpdateLabelInput struct {
 	LabelID string `json:"label_id" jsonschema:"The label ID to update"`
 	Name    string `json:"name,omitempty" jsonschema:"New name (optional)"`
 	Color   string `json:"color,omitempty" jsonschema:"New color (optional)"`
 }
-type UpdateLabelOutput struct {
-	Success bool   `json:"success"`
-	Message string `json:"message"`
-}
-
 type DeleteLabelInput struct {
 	LabelID string `json:"label_id" jsonschema:"The label ID to delete"`
-}
-type DeleteLabelOutput struct {
-	Success bool   `json:"success"`
-	Message string `json:"message"`
 }
 
 func registerLabelTools(s *mcp.Server, c *todoist.Client) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "todoist_get_labels",
 		Description: "List all personal labels",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, input GetLabelsInput) (*mcp.CallToolResult, GetLabelsOutput, error) {
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input GetLabelsInput) (*mcp.CallToolResult, ActionOutput, error) {
 		labels, err := c.GetLabels(ctx)
 		if err != nil {
-			return nil, GetLabelsOutput{}, err
+			return nil, ActionOutput{}, err
 		}
 
 		if len(labels) == 0 {
 			msg := "No labels found"
-			return textResult(msg, false), GetLabelsOutput{Success: true, Message: msg}, nil
+			return textResult(msg, false), ActionOutput{Success: true, Message: msg}, nil
 		}
 
 		var lines []string
@@ -67,13 +48,13 @@ func registerLabelTools(s *mcp.Server, c *todoist.Client) {
 			lines = append(lines, line)
 		}
 		msg := strings.Join(lines, "\n")
-		return textResult(msg, false), GetLabelsOutput{Success: true, Message: msg}, nil
+		return textResult(msg, false), ActionOutput{Success: true, Message: msg}, nil
 	})
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "todoist_create_label",
 		Description: "Create a new personal label",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, input CreateLabelInput) (*mcp.CallToolResult, CreateLabelOutput, error) {
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input CreateLabelInput) (*mcp.CallToolResult, ActionOutput, error) {
 		createReq := todoist.CreateLabelRequest{Name: input.Name}
 		if input.Color != "" {
 			createReq.Color = new(input.Color)
@@ -83,17 +64,17 @@ func registerLabelTools(s *mcp.Server, c *todoist.Client) {
 		}
 		l, err := c.CreateLabel(ctx, createReq)
 		if err != nil {
-			return nil, CreateLabelOutput{Success: false, Message: err.Error()}, err
+			return nil, ActionOutput{Success: false, Message: err.Error()}, err
 		}
 
 		msg := fmt.Sprintf("Label created: %s (ID: %s)", l.Name, l.ID)
-		return textResult(msg, false), CreateLabelOutput{Success: true, Message: msg}, nil
+		return textResult(msg, false), ActionOutput{Success: true, Message: msg}, nil
 	})
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "todoist_update_label",
 		Description: "Update an existing label",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, input UpdateLabelInput) (*mcp.CallToolResult, UpdateLabelOutput, error) {
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input UpdateLabelInput) (*mcp.CallToolResult, ActionOutput, error) {
 		updateReq := todoist.UpdateLabelRequest{}
 		if input.Name != "" {
 			updateReq.Name = new(input.Name)
@@ -103,21 +84,21 @@ func registerLabelTools(s *mcp.Server, c *todoist.Client) {
 		}
 		l, err := c.UpdateLabel(ctx, input.LabelID, updateReq)
 		if err != nil {
-			return nil, UpdateLabelOutput{Success: false, Message: err.Error()}, err
+			return nil, ActionOutput{Success: false, Message: err.Error()}, err
 		}
 
 		msg := fmt.Sprintf("Label updated: %s (ID: %s)", l.Name, l.ID)
-		return textResult(msg, false), UpdateLabelOutput{Success: true, Message: msg}, nil
+		return textResult(msg, false), ActionOutput{Success: true, Message: msg}, nil
 	})
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "todoist_delete_label",
 		Description: "Delete a label",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, input DeleteLabelInput) (*mcp.CallToolResult, DeleteLabelOutput, error) {
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input DeleteLabelInput) (*mcp.CallToolResult, ActionOutput, error) {
 		if err := c.DeleteLabel(ctx, input.LabelID); err != nil {
-			return nil, DeleteLabelOutput{Success: false, Message: err.Error()}, err
+			return nil, ActionOutput{Success: false, Message: err.Error()}, err
 		}
 		msg := fmt.Sprintf("Successfully deleted label: %s", input.LabelID)
-		return textResult(msg, false), DeleteLabelOutput{Success: true, Message: msg}, nil
+		return textResult(msg, false), ActionOutput{Success: true, Message: msg}, nil
 	})
 }

--- a/internal/tools/output.go
+++ b/internal/tools/output.go
@@ -1,0 +1,17 @@
+package tools
+
+import "github.com/modelcontextprotocol/go-sdk/mcp"
+
+// ActionOutput is the shared structured output for all tools: a success
+// flag plus the same human-readable message returned as text content.
+type ActionOutput struct {
+	Success bool   `json:"success"`
+	Message string `json:"message"`
+}
+
+func textResult(msg string, isError bool) *mcp.CallToolResult {
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: msg}},
+		IsError: isError,
+	}
+}

--- a/internal/tools/projects.go
+++ b/internal/tools/projects.go
@@ -10,19 +10,9 @@ import (
 )
 
 type GetProjectsInput struct{}
-type GetProjectsOutput struct {
-	Success bool   `json:"success"`
-	Message string `json:"message"`
-}
-
 type GetProjectInput struct {
 	ProjectID string `json:"project_id" jsonschema:"The project ID to retrieve"`
 }
-type GetProjectOutput struct {
-	Success bool   `json:"success"`
-	Message string `json:"message"`
-}
-
 type CreateProjectInput struct {
 	Name       string `json:"name" jsonschema:"Name of the project"`
 	ParentID   string `json:"parent_id,omitempty" jsonschema:"Parent project ID (optional)"`
@@ -30,59 +20,35 @@ type CreateProjectInput struct {
 	IsFavorite bool   `json:"is_favorite,omitempty" jsonschema:"Whether the project is a favorite (optional)"`
 	ViewStyle  string `json:"view_style,omitempty" jsonschema:"View style: list or board (optional)"`
 }
-type CreateProjectOutput struct {
-	Success bool   `json:"success"`
-	Message string `json:"message"`
-}
-
 type UpdateProjectInput struct {
 	ProjectID  string `json:"project_id" jsonschema:"The project ID to update"`
 	Name       string `json:"name,omitempty" jsonschema:"New name (optional)"`
 	Color      string `json:"color,omitempty" jsonschema:"New color (optional)"`
 	IsFavorite *bool  `json:"is_favorite,omitempty" jsonschema:"Set favorite status (optional)"`
 }
-type UpdateProjectOutput struct {
-	Success bool   `json:"success"`
-	Message string `json:"message"`
-}
-
 type DeleteProjectInput struct {
 	ProjectID string `json:"project_id" jsonschema:"The project ID to delete"`
 }
-type DeleteProjectOutput struct {
-	Success bool   `json:"success"`
-	Message string `json:"message"`
-}
-
 type ArchiveProjectInput struct {
 	ProjectID string `json:"project_id" jsonschema:"The project ID to archive"`
 }
-type ArchiveProjectOutput struct {
-	Success bool   `json:"success"`
-	Message string `json:"message"`
-}
-
 type UnarchiveProjectInput struct {
 	ProjectID string `json:"project_id" jsonschema:"The project ID to unarchive"`
-}
-type UnarchiveProjectOutput struct {
-	Success bool   `json:"success"`
-	Message string `json:"message"`
 }
 
 func registerProjectTools(s *mcp.Server, c *todoist.Client) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "todoist_get_projects",
 		Description: "List all Todoist projects",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, input GetProjectsInput) (*mcp.CallToolResult, GetProjectsOutput, error) {
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input GetProjectsInput) (*mcp.CallToolResult, ActionOutput, error) {
 		projects, err := c.GetProjects(ctx)
 		if err != nil {
-			return nil, GetProjectsOutput{}, err
+			return nil, ActionOutput{}, err
 		}
 
 		if len(projects) == 0 {
 			msg := "No projects found"
-			return textResult(msg, false), GetProjectsOutput{Success: true, Message: msg}, nil
+			return textResult(msg, false), ActionOutput{Success: true, Message: msg}, nil
 		}
 
 		var lines []string
@@ -97,16 +63,16 @@ func registerProjectTools(s *mcp.Server, c *todoist.Client) {
 			lines = append(lines, line)
 		}
 		msg := strings.Join(lines, "\n")
-		return textResult(msg, false), GetProjectsOutput{Success: true, Message: msg}, nil
+		return textResult(msg, false), ActionOutput{Success: true, Message: msg}, nil
 	})
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "todoist_get_project",
 		Description: "Get a single Todoist project by ID",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, input GetProjectInput) (*mcp.CallToolResult, GetProjectOutput, error) {
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input GetProjectInput) (*mcp.CallToolResult, ActionOutput, error) {
 		p, err := c.GetProject(ctx, input.ProjectID)
 		if err != nil {
-			return nil, GetProjectOutput{}, err
+			return nil, ActionOutput{}, err
 		}
 
 		msg := fmt.Sprintf("Project: %s\nID: %s\nColor: %s\nFavorite: %v\nShared: %v\nInbox: %v",
@@ -114,13 +80,13 @@ func registerProjectTools(s *mcp.Server, c *todoist.Client) {
 		if p.URL != "" {
 			msg += fmt.Sprintf("\nURL: %s", p.URL)
 		}
-		return textResult(msg, false), GetProjectOutput{Success: true, Message: msg}, nil
+		return textResult(msg, false), ActionOutput{Success: true, Message: msg}, nil
 	})
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "todoist_create_project",
 		Description: "Create a new Todoist project",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, input CreateProjectInput) (*mcp.CallToolResult, CreateProjectOutput, error) {
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input CreateProjectInput) (*mcp.CallToolResult, ActionOutput, error) {
 		createReq := todoist.CreateProjectRequest{Name: input.Name}
 		if input.ParentID != "" {
 			createReq.ParentID = new(input.ParentID)
@@ -136,17 +102,17 @@ func registerProjectTools(s *mcp.Server, c *todoist.Client) {
 		}
 		p, err := c.CreateProject(ctx, createReq)
 		if err != nil {
-			return nil, CreateProjectOutput{Success: false, Message: err.Error()}, err
+			return nil, ActionOutput{Success: false, Message: err.Error()}, err
 		}
 
 		msg := fmt.Sprintf("Project created: %s (ID: %s)", p.Name, p.ID)
-		return textResult(msg, false), CreateProjectOutput{Success: true, Message: msg}, nil
+		return textResult(msg, false), ActionOutput{Success: true, Message: msg}, nil
 	})
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "todoist_update_project",
 		Description: "Update an existing Todoist project",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, input UpdateProjectInput) (*mcp.CallToolResult, UpdateProjectOutput, error) {
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input UpdateProjectInput) (*mcp.CallToolResult, ActionOutput, error) {
 		updateReq := todoist.UpdateProjectRequest{}
 		if input.Name != "" {
 			updateReq.Name = new(input.Name)
@@ -159,43 +125,43 @@ func registerProjectTools(s *mcp.Server, c *todoist.Client) {
 		}
 		p, err := c.UpdateProject(ctx, input.ProjectID, updateReq)
 		if err != nil {
-			return nil, UpdateProjectOutput{Success: false, Message: err.Error()}, err
+			return nil, ActionOutput{Success: false, Message: err.Error()}, err
 		}
 
 		msg := fmt.Sprintf("Project updated: %s (ID: %s)", p.Name, p.ID)
-		return textResult(msg, false), UpdateProjectOutput{Success: true, Message: msg}, nil
+		return textResult(msg, false), ActionOutput{Success: true, Message: msg}, nil
 	})
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "todoist_delete_project",
 		Description: "Delete a Todoist project",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, input DeleteProjectInput) (*mcp.CallToolResult, DeleteProjectOutput, error) {
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input DeleteProjectInput) (*mcp.CallToolResult, ActionOutput, error) {
 		if err := c.DeleteProject(ctx, input.ProjectID); err != nil {
-			return nil, DeleteProjectOutput{Success: false, Message: err.Error()}, err
+			return nil, ActionOutput{Success: false, Message: err.Error()}, err
 		}
 		msg := fmt.Sprintf("Successfully deleted project: %s", input.ProjectID)
-		return textResult(msg, false), DeleteProjectOutput{Success: true, Message: msg}, nil
+		return textResult(msg, false), ActionOutput{Success: true, Message: msg}, nil
 	})
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "todoist_archive_project",
 		Description: "Archive a Todoist project",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, input ArchiveProjectInput) (*mcp.CallToolResult, ArchiveProjectOutput, error) {
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input ArchiveProjectInput) (*mcp.CallToolResult, ActionOutput, error) {
 		if err := c.ArchiveProject(ctx, input.ProjectID); err != nil {
-			return nil, ArchiveProjectOutput{Success: false, Message: err.Error()}, err
+			return nil, ActionOutput{Success: false, Message: err.Error()}, err
 		}
 		msg := fmt.Sprintf("Successfully archived project: %s", input.ProjectID)
-		return textResult(msg, false), ArchiveProjectOutput{Success: true, Message: msg}, nil
+		return textResult(msg, false), ActionOutput{Success: true, Message: msg}, nil
 	})
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "todoist_unarchive_project",
 		Description: "Unarchive a Todoist project",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, input UnarchiveProjectInput) (*mcp.CallToolResult, UnarchiveProjectOutput, error) {
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input UnarchiveProjectInput) (*mcp.CallToolResult, ActionOutput, error) {
 		if err := c.UnarchiveProject(ctx, input.ProjectID); err != nil {
-			return nil, UnarchiveProjectOutput{Success: false, Message: err.Error()}, err
+			return nil, ActionOutput{Success: false, Message: err.Error()}, err
 		}
 		msg := fmt.Sprintf("Successfully unarchived project: %s", input.ProjectID)
-		return textResult(msg, false), UnarchiveProjectOutput{Success: true, Message: msg}, nil
+		return textResult(msg, false), ActionOutput{Success: true, Message: msg}, nil
 	})
 }

--- a/internal/tools/sections.go
+++ b/internal/tools/sections.go
@@ -12,51 +12,32 @@ import (
 type GetSectionsInput struct {
 	ProjectID string `json:"project_id,omitempty" jsonschema:"Filter sections by project ID (optional)"`
 }
-type GetSectionsOutput struct {
-	Success bool   `json:"success"`
-	Message string `json:"message"`
-}
-
 type CreateSectionInput struct {
 	Name      string `json:"name" jsonschema:"Name of the section"`
 	ProjectID string `json:"project_id" jsonschema:"Project ID the section belongs to"`
 	Order     int    `json:"order,omitempty" jsonschema:"Order among other sections (optional)"`
 }
-type CreateSectionOutput struct {
-	Success bool   `json:"success"`
-	Message string `json:"message"`
-}
-
 type UpdateSectionInput struct {
 	SectionID string `json:"section_id" jsonschema:"The section ID to update"`
 	Name      string `json:"name" jsonschema:"New name for the section"`
 }
-type UpdateSectionOutput struct {
-	Success bool   `json:"success"`
-	Message string `json:"message"`
-}
-
 type DeleteSectionInput struct {
 	SectionID string `json:"section_id" jsonschema:"The section ID to delete"`
-}
-type DeleteSectionOutput struct {
-	Success bool   `json:"success"`
-	Message string `json:"message"`
 }
 
 func registerSectionTools(s *mcp.Server, c *todoist.Client) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "todoist_get_sections",
 		Description: "List sections, optionally filtered by project",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, input GetSectionsInput) (*mcp.CallToolResult, GetSectionsOutput, error) {
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input GetSectionsInput) (*mcp.CallToolResult, ActionOutput, error) {
 		sections, err := c.GetSections(ctx, input.ProjectID)
 		if err != nil {
-			return nil, GetSectionsOutput{}, err
+			return nil, ActionOutput{}, err
 		}
 
 		if len(sections) == 0 {
 			msg := "No sections found"
-			return textResult(msg, false), GetSectionsOutput{Success: true, Message: msg}, nil
+			return textResult(msg, false), ActionOutput{Success: true, Message: msg}, nil
 		}
 
 		var lines []string
@@ -64,47 +45,47 @@ func registerSectionTools(s *mcp.Server, c *todoist.Client) {
 			lines = append(lines, fmt.Sprintf("- %s (ID: %s, Project: %s)", sec.Name, sec.ID, sec.ProjectID))
 		}
 		msg := strings.Join(lines, "\n")
-		return textResult(msg, false), GetSectionsOutput{Success: true, Message: msg}, nil
+		return textResult(msg, false), ActionOutput{Success: true, Message: msg}, nil
 	})
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "todoist_create_section",
 		Description: "Create a new section in a Todoist project",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, input CreateSectionInput) (*mcp.CallToolResult, CreateSectionOutput, error) {
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input CreateSectionInput) (*mcp.CallToolResult, ActionOutput, error) {
 		createReq := todoist.CreateSectionRequest{Name: input.Name, ProjectID: input.ProjectID}
 		if input.Order > 0 {
 			createReq.SectionOrder = new(input.Order)
 		}
 		sec, err := c.CreateSection(ctx, createReq)
 		if err != nil {
-			return nil, CreateSectionOutput{Success: false, Message: err.Error()}, err
+			return nil, ActionOutput{Success: false, Message: err.Error()}, err
 		}
 
 		msg := fmt.Sprintf("Section created: %s (ID: %s)", sec.Name, sec.ID)
-		return textResult(msg, false), CreateSectionOutput{Success: true, Message: msg}, nil
+		return textResult(msg, false), ActionOutput{Success: true, Message: msg}, nil
 	})
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "todoist_update_section",
 		Description: "Update an existing section name",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, input UpdateSectionInput) (*mcp.CallToolResult, UpdateSectionOutput, error) {
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input UpdateSectionInput) (*mcp.CallToolResult, ActionOutput, error) {
 		sec, err := c.UpdateSection(ctx, input.SectionID, todoist.UpdateSectionRequest{Name: input.Name})
 		if err != nil {
-			return nil, UpdateSectionOutput{Success: false, Message: err.Error()}, err
+			return nil, ActionOutput{Success: false, Message: err.Error()}, err
 		}
 
 		msg := fmt.Sprintf("Section updated: %s (ID: %s)", sec.Name, sec.ID)
-		return textResult(msg, false), UpdateSectionOutput{Success: true, Message: msg}, nil
+		return textResult(msg, false), ActionOutput{Success: true, Message: msg}, nil
 	})
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "todoist_delete_section",
 		Description: "Delete a section from a Todoist project",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, input DeleteSectionInput) (*mcp.CallToolResult, DeleteSectionOutput, error) {
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input DeleteSectionInput) (*mcp.CallToolResult, ActionOutput, error) {
 		if err := c.DeleteSection(ctx, input.SectionID); err != nil {
-			return nil, DeleteSectionOutput{Success: false, Message: err.Error()}, err
+			return nil, ActionOutput{Success: false, Message: err.Error()}, err
 		}
 		msg := fmt.Sprintf("Successfully deleted section: %s", input.SectionID)
-		return textResult(msg, false), DeleteSectionOutput{Success: true, Message: msg}, nil
+		return textResult(msg, false), ActionOutput{Success: true, Message: msg}, nil
 	})
 }

--- a/internal/tools/tasks.go
+++ b/internal/tools/tasks.go
@@ -24,21 +24,11 @@ type CreateTaskInput struct {
 	AssigneeID  string   `json:"assignee_id,omitempty" jsonschema:"User ID to assign the task to (optional)"`
 }
 
-type CreateTaskOutput struct {
-	Success bool   `json:"success"`
-	Message string `json:"message"`
-}
-
 type GetTasksInput struct {
 	ProjectID string `json:"project_id,omitempty" jsonschema:"Filter tasks by project ID (optional)"`
 	Filter    string `json:"filter,omitempty" jsonschema:"Natural language filter like 'today', 'tomorrow', 'next week', 'priority 1', 'overdue' (optional)"`
 	Priority  int    `json:"priority,omitempty" jsonschema:"Filter by priority level (1-4) (optional)"`
 	Limit     int    `json:"limit,omitempty" jsonschema:"Maximum number of tasks to return (optional, default 10)"`
-}
-
-type GetTasksOutput struct {
-	Success bool   `json:"success"`
-	Message string `json:"message"`
 }
 
 type UpdateTaskInput struct {
@@ -53,19 +43,9 @@ type UpdateTaskInput struct {
 	DeadlineDate string   `json:"deadline_date,omitempty" jsonschema:"New deadline date in YYYY-MM-DD format (optional)"`
 }
 
-type UpdateTaskOutput struct {
-	Success bool   `json:"success"`
-	Message string `json:"message"`
-}
-
 type DeleteTaskInput struct {
 	TaskID   string `json:"task_id,omitempty" jsonschema:"Task ID to delete (preferred over task_name)"`
 	TaskName string `json:"task_name,omitempty" jsonschema:"Name/content of the task to search for and delete"`
-}
-
-type DeleteTaskOutput struct {
-	Success bool   `json:"success"`
-	Message string `json:"message"`
 }
 
 type CompleteTaskInput struct {
@@ -73,19 +53,9 @@ type CompleteTaskInput struct {
 	TaskName string `json:"task_name,omitempty" jsonschema:"Name/content of the task to search for and complete"`
 }
 
-type CompleteTaskOutput struct {
-	Success bool   `json:"success"`
-	Message string `json:"message"`
-}
-
 type ReopenTaskInput struct {
 	TaskID   string `json:"task_id,omitempty" jsonschema:"Task ID to reopen (preferred over task_name)"`
 	TaskName string `json:"task_name,omitempty" jsonschema:"Name/content of the task to search for and reopen"`
-}
-
-type ReopenTaskOutput struct {
-	Success bool   `json:"success"`
-	Message string `json:"message"`
 }
 
 // --- helpers ---
@@ -107,20 +77,13 @@ func resolveTaskID(ctx context.Context, c *todoist.Client, id, name string) (str
 	return task.ID, task.Content, nil
 }
 
-func textResult(msg string, isError bool) *mcp.CallToolResult {
-	return &mcp.CallToolResult{
-		Content: []mcp.Content{&mcp.TextContent{Text: msg}},
-		IsError: isError,
-	}
-}
-
 // --- registrations ---
 
 func registerTaskTools(s *mcp.Server, c *todoist.Client) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "todoist_create_task",
 		Description: "Create a new task in Todoist with optional description, due date, priority, project, section, labels, and assignee",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, input CreateTaskInput) (*mcp.CallToolResult, CreateTaskOutput, error) {
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input CreateTaskInput) (*mcp.CallToolResult, ActionOutput, error) {
 		createReq := todoist.CreateTaskRequest{Content: input.Content}
 		if input.Description != "" {
 			createReq.Description = new(input.Description)
@@ -149,7 +112,7 @@ func registerTaskTools(s *mcp.Server, c *todoist.Client) {
 
 		task, err := c.CreateTask(ctx, createReq)
 		if err != nil {
-			return nil, CreateTaskOutput{Success: false, Message: err.Error()}, err
+			return nil, ActionOutput{Success: false, Message: err.Error()}, err
 		}
 
 		msg := fmt.Sprintf("Task created:\nTitle: %s", task.Content)
@@ -163,13 +126,13 @@ func registerTaskTools(s *mcp.Server, c *todoist.Client) {
 			msg += fmt.Sprintf("\nPriority: %d", task.Priority)
 		}
 
-		return textResult(msg, false), CreateTaskOutput{Success: true, Message: msg}, nil
+		return textResult(msg, false), ActionOutput{Success: true, Message: msg}, nil
 	})
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "todoist_get_tasks",
 		Description: "Get a list of tasks from Todoist with various filters",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, input GetTasksInput) (*mcp.CallToolResult, GetTasksOutput, error) {
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input GetTasksInput) (*mcp.CallToolResult, ActionOutput, error) {
 		var tasks []models.Task
 		var err error
 		if input.Filter != "" {
@@ -178,7 +141,7 @@ func registerTaskTools(s *mcp.Server, c *todoist.Client) {
 			tasks, err = c.GetTasks(ctx, input.ProjectID)
 		}
 		if err != nil {
-			return nil, GetTasksOutput{}, err
+			return nil, ActionOutput{}, err
 		}
 
 		// Apply priority filter.
@@ -222,20 +185,20 @@ func registerTaskTools(s *mcp.Server, c *todoist.Client) {
 			msg = strings.Join(lines, "\n\n")
 		}
 
-		return textResult(msg, false), GetTasksOutput{Success: true, Message: msg}, nil
+		return textResult(msg, false), ActionOutput{Success: true, Message: msg}, nil
 	})
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "todoist_update_task",
 		Description: "Update an existing task in Todoist by task_id or by searching by name",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, input UpdateTaskInput) (*mcp.CallToolResult, UpdateTaskOutput, error) {
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input UpdateTaskInput) (*mcp.CallToolResult, ActionOutput, error) {
 		id, originalName, err := resolveTaskID(ctx, c, input.TaskID, input.TaskName)
 		if err != nil {
-			return nil, UpdateTaskOutput{Success: false, Message: err.Error()}, err
+			return nil, ActionOutput{Success: false, Message: err.Error()}, err
 		}
 		if id == "" {
 			msg := fmt.Sprintf("Could not find a task matching \"%s\"", input.TaskName)
-			return textResult(msg, true), UpdateTaskOutput{Success: false, Message: msg}, nil
+			return textResult(msg, true), ActionOutput{Success: false, Message: msg}, nil
 		}
 
 		updateReq := todoist.UpdateTaskRequest{}
@@ -263,7 +226,7 @@ func registerTaskTools(s *mcp.Server, c *todoist.Client) {
 
 		updated, err := c.UpdateTask(ctx, id, updateReq)
 		if err != nil {
-			return nil, UpdateTaskOutput{Success: false, Message: err.Error()}, err
+			return nil, ActionOutput{Success: false, Message: err.Error()}, err
 		}
 
 		label := originalName
@@ -281,24 +244,24 @@ func registerTaskTools(s *mcp.Server, c *todoist.Client) {
 			msg += fmt.Sprintf("\nNew Priority: %d", updated.Priority)
 		}
 
-		return textResult(msg, false), UpdateTaskOutput{Success: true, Message: msg}, nil
+		return textResult(msg, false), ActionOutput{Success: true, Message: msg}, nil
 	})
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "todoist_delete_task",
 		Description: "Delete a task from Todoist by task_id or by searching by name",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, input DeleteTaskInput) (*mcp.CallToolResult, DeleteTaskOutput, error) {
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input DeleteTaskInput) (*mcp.CallToolResult, ActionOutput, error) {
 		id, originalName, err := resolveTaskID(ctx, c, input.TaskID, input.TaskName)
 		if err != nil {
-			return nil, DeleteTaskOutput{Success: false, Message: err.Error()}, err
+			return nil, ActionOutput{Success: false, Message: err.Error()}, err
 		}
 		if id == "" {
 			msg := fmt.Sprintf("Could not find a task matching \"%s\"", input.TaskName)
-			return textResult(msg, true), DeleteTaskOutput{Success: false, Message: msg}, nil
+			return textResult(msg, true), ActionOutput{Success: false, Message: msg}, nil
 		}
 
 		if err := c.DeleteTask(ctx, id); err != nil {
-			return nil, DeleteTaskOutput{Success: false, Message: err.Error()}, err
+			return nil, ActionOutput{Success: false, Message: err.Error()}, err
 		}
 
 		label := originalName
@@ -306,24 +269,24 @@ func registerTaskTools(s *mcp.Server, c *todoist.Client) {
 			label = id
 		}
 		msg := fmt.Sprintf("Successfully deleted task: \"%s\"", label)
-		return textResult(msg, false), DeleteTaskOutput{Success: true, Message: msg}, nil
+		return textResult(msg, false), ActionOutput{Success: true, Message: msg}, nil
 	})
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "todoist_complete_task",
 		Description: "Mark a task as complete by task_id or by searching by name",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, input CompleteTaskInput) (*mcp.CallToolResult, CompleteTaskOutput, error) {
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input CompleteTaskInput) (*mcp.CallToolResult, ActionOutput, error) {
 		id, originalName, err := resolveTaskID(ctx, c, input.TaskID, input.TaskName)
 		if err != nil {
-			return nil, CompleteTaskOutput{Success: false, Message: err.Error()}, err
+			return nil, ActionOutput{Success: false, Message: err.Error()}, err
 		}
 		if id == "" {
 			msg := fmt.Sprintf("Could not find a task matching \"%s\"", input.TaskName)
-			return textResult(msg, true), CompleteTaskOutput{Success: false, Message: msg}, nil
+			return textResult(msg, true), ActionOutput{Success: false, Message: msg}, nil
 		}
 
 		if err := c.CloseTask(ctx, id); err != nil {
-			return nil, CompleteTaskOutput{Success: false, Message: err.Error()}, err
+			return nil, ActionOutput{Success: false, Message: err.Error()}, err
 		}
 
 		label := originalName
@@ -331,24 +294,24 @@ func registerTaskTools(s *mcp.Server, c *todoist.Client) {
 			label = id
 		}
 		msg := fmt.Sprintf("Successfully completed task: \"%s\"", label)
-		return textResult(msg, false), CompleteTaskOutput{Success: true, Message: msg}, nil
+		return textResult(msg, false), ActionOutput{Success: true, Message: msg}, nil
 	})
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "todoist_reopen_task",
 		Description: "Reopen a completed task by task_id or by searching by name",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, input ReopenTaskInput) (*mcp.CallToolResult, ReopenTaskOutput, error) {
+	}, func(ctx context.Context, req *mcp.CallToolRequest, input ReopenTaskInput) (*mcp.CallToolResult, ActionOutput, error) {
 		id, originalName, err := resolveTaskID(ctx, c, input.TaskID, input.TaskName)
 		if err != nil {
-			return nil, ReopenTaskOutput{Success: false, Message: err.Error()}, err
+			return nil, ActionOutput{Success: false, Message: err.Error()}, err
 		}
 		if id == "" {
 			msg := fmt.Sprintf("Could not find a task matching \"%s\"", input.TaskName)
-			return textResult(msg, true), ReopenTaskOutput{Success: false, Message: msg}, nil
+			return textResult(msg, true), ActionOutput{Success: false, Message: msg}, nil
 		}
 
 		if err := c.ReopenTask(ctx, id); err != nil {
-			return nil, ReopenTaskOutput{Success: false, Message: err.Error()}, err
+			return nil, ActionOutput{Success: false, Message: err.Error()}, err
 		}
 
 		label := originalName
@@ -356,6 +319,6 @@ func registerTaskTools(s *mcp.Server, c *todoist.Client) {
 			label = id
 		}
 		msg := fmt.Sprintf("Successfully reopened task: \"%s\"", label)
-		return textResult(msg, false), ReopenTaskOutput{Success: true, Message: msg}, nil
+		return textResult(msg, false), ActionOutput{Success: true, Message: msg}, nil
 	})
 }

--- a/internal/tools/tasks.go
+++ b/internal/tools/tasks.go
@@ -77,6 +77,39 @@ func resolveTaskID(ctx context.Context, c *todoist.Client, id, name string) (str
 	return task.ID, task.Content, nil
 }
 
+// resolveTask resolves a task by ID or name and returns a display label
+// (the matched task name, falling back to the ID). taskID is "" when a
+// name search found nothing.
+func resolveTask(ctx context.Context, c *todoist.Client, id, name string) (taskID, label string, err error) {
+	taskID, originalName, err := resolveTaskID(ctx, c, id, name)
+	if err != nil || taskID == "" {
+		return taskID, "", err
+	}
+	label = originalName
+	if label == "" {
+		label = taskID
+	}
+	return taskID, label, nil
+}
+
+// runTaskAction runs the shared resolve, not-found, act, report flow for
+// task tools whose success message is "Successfully <verb> task: ...".
+func runTaskAction(ctx context.Context, c *todoist.Client, id, name, verb string, action func(context.Context, string) error) (*mcp.CallToolResult, ActionOutput, error) {
+	taskID, label, err := resolveTask(ctx, c, id, name)
+	if err != nil {
+		return nil, ActionOutput{Success: false, Message: err.Error()}, err
+	}
+	if taskID == "" {
+		msg := fmt.Sprintf("Could not find a task matching \"%s\"", name)
+		return textResult(msg, true), ActionOutput{Success: false, Message: msg}, nil
+	}
+	if err := action(ctx, taskID); err != nil {
+		return nil, ActionOutput{Success: false, Message: err.Error()}, err
+	}
+	msg := fmt.Sprintf("Successfully %s task: \"%s\"", verb, label)
+	return textResult(msg, false), ActionOutput{Success: true, Message: msg}, nil
+}
+
 // --- registrations ---
 
 func registerTaskTools(s *mcp.Server, c *todoist.Client) {
@@ -192,7 +225,7 @@ func registerTaskTools(s *mcp.Server, c *todoist.Client) {
 		Name:        "todoist_update_task",
 		Description: "Update an existing task in Todoist by task_id or by searching by name",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input UpdateTaskInput) (*mcp.CallToolResult, ActionOutput, error) {
-		id, originalName, err := resolveTaskID(ctx, c, input.TaskID, input.TaskName)
+		id, label, err := resolveTask(ctx, c, input.TaskID, input.TaskName)
 		if err != nil {
 			return nil, ActionOutput{Success: false, Message: err.Error()}, err
 		}
@@ -229,10 +262,6 @@ func registerTaskTools(s *mcp.Server, c *todoist.Client) {
 			return nil, ActionOutput{Success: false, Message: err.Error()}, err
 		}
 
-		label := originalName
-		if label == "" {
-			label = id
-		}
 		msg := fmt.Sprintf("Task \"%s\" updated:\nNew Title: %s", label, updated.Content)
 		if updated.Description != "" {
 			msg += fmt.Sprintf("\nNew Description: %s", updated.Description)
@@ -251,74 +280,20 @@ func registerTaskTools(s *mcp.Server, c *todoist.Client) {
 		Name:        "todoist_delete_task",
 		Description: "Delete a task from Todoist by task_id or by searching by name",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input DeleteTaskInput) (*mcp.CallToolResult, ActionOutput, error) {
-		id, originalName, err := resolveTaskID(ctx, c, input.TaskID, input.TaskName)
-		if err != nil {
-			return nil, ActionOutput{Success: false, Message: err.Error()}, err
-		}
-		if id == "" {
-			msg := fmt.Sprintf("Could not find a task matching \"%s\"", input.TaskName)
-			return textResult(msg, true), ActionOutput{Success: false, Message: msg}, nil
-		}
-
-		if err := c.DeleteTask(ctx, id); err != nil {
-			return nil, ActionOutput{Success: false, Message: err.Error()}, err
-		}
-
-		label := originalName
-		if label == "" {
-			label = id
-		}
-		msg := fmt.Sprintf("Successfully deleted task: \"%s\"", label)
-		return textResult(msg, false), ActionOutput{Success: true, Message: msg}, nil
+		return runTaskAction(ctx, c, input.TaskID, input.TaskName, "deleted", c.DeleteTask)
 	})
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "todoist_complete_task",
 		Description: "Mark a task as complete by task_id or by searching by name",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input CompleteTaskInput) (*mcp.CallToolResult, ActionOutput, error) {
-		id, originalName, err := resolveTaskID(ctx, c, input.TaskID, input.TaskName)
-		if err != nil {
-			return nil, ActionOutput{Success: false, Message: err.Error()}, err
-		}
-		if id == "" {
-			msg := fmt.Sprintf("Could not find a task matching \"%s\"", input.TaskName)
-			return textResult(msg, true), ActionOutput{Success: false, Message: msg}, nil
-		}
-
-		if err := c.CloseTask(ctx, id); err != nil {
-			return nil, ActionOutput{Success: false, Message: err.Error()}, err
-		}
-
-		label := originalName
-		if label == "" {
-			label = id
-		}
-		msg := fmt.Sprintf("Successfully completed task: \"%s\"", label)
-		return textResult(msg, false), ActionOutput{Success: true, Message: msg}, nil
+		return runTaskAction(ctx, c, input.TaskID, input.TaskName, "completed", c.CloseTask)
 	})
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "todoist_reopen_task",
 		Description: "Reopen a completed task by task_id or by searching by name",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input ReopenTaskInput) (*mcp.CallToolResult, ActionOutput, error) {
-		id, originalName, err := resolveTaskID(ctx, c, input.TaskID, input.TaskName)
-		if err != nil {
-			return nil, ActionOutput{Success: false, Message: err.Error()}, err
-		}
-		if id == "" {
-			msg := fmt.Sprintf("Could not find a task matching \"%s\"", input.TaskName)
-			return textResult(msg, true), ActionOutput{Success: false, Message: msg}, nil
-		}
-
-		if err := c.ReopenTask(ctx, id); err != nil {
-			return nil, ActionOutput{Success: false, Message: err.Error()}, err
-		}
-
-		label := originalName
-		if label == "" {
-			label = id
-		}
-		msg := fmt.Sprintf("Successfully reopened task: \"%s\"", label)
-		return textResult(msg, false), ActionOutput{Success: true, Message: msg}, nil
+		return runTaskAction(ctx, c, input.TaskID, input.TaskName, "reopened", c.ReopenTask)
 	})
 }


### PR DESCRIPTION
Stage 3 of the tech debt refactor (spec: docs/superpowers/specs/2026-07-14-tech-debt-refactor-design.md). Collapses 29 identical per-tool output structs into a shared ActionOutput and extracts the repeated resolve/not-found/act/report flow into resolveTask and runTaskAction helpers. Wire behavior and user-visible messages are byte-identical; no test assertions changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015j22Jr9L3mzY3wNohfvWcu