### PR TITLE
feat: stage 4 update field clearing

### DIFF
--- a/internal/tools/tasks.go
+++ b/internal/tools/tasks.go
@@ -32,15 +32,15 @@ type GetTasksInput struct {
 }
 
 type UpdateTaskInput struct {
-	TaskID       string   `json:"task_id,omitempty" jsonschema:"Task ID to update (preferred over task_name)"`
-	TaskName     string   `json:"task_name,omitempty" jsonschema:"Name/content of the task to search for and update"`
-	Content      string   `json:"content,omitempty" jsonschema:"New content/title for the task (optional)"`
-	Description  string   `json:"description,omitempty" jsonschema:"New description for the task (optional)"`
-	DueString    string   `json:"due_string,omitempty" jsonschema:"New due date in natural language (optional)"`
-	Priority     int      `json:"priority,omitempty" jsonschema:"New priority level from 1 (normal) to 4 (urgent) (optional)"`
-	Labels       []string `json:"labels,omitempty" jsonschema:"New labels for the task (optional)"`
-	AssigneeID   string   `json:"assignee_id,omitempty" jsonschema:"User ID to assign the task to (optional)"`
-	DeadlineDate string   `json:"deadline_date,omitempty" jsonschema:"New deadline date in YYYY-MM-DD format (optional)"`
+	TaskID       string    `json:"task_id,omitempty" jsonschema:"Task ID to update (preferred over task_name)"`
+	TaskName     string    `json:"task_name,omitempty" jsonschema:"Name/content of the task to search for and update"`
+	Content      string    `json:"content,omitempty" jsonschema:"New content/title for the task (optional)"`
+	Description  *string   `json:"description,omitempty" jsonschema:"New description for the task. An empty string clears it (optional)"`
+	DueString    *string   `json:"due_string,omitempty" jsonschema:"New due date in natural language. An empty string or 'no date' removes the due date (optional)"`
+	Priority     int       `json:"priority,omitempty" jsonschema:"New priority level from 1 (normal) to 4 (urgent) (optional)"`
+	Labels       *[]string `json:"labels,omitempty" jsonschema:"New labels for the task. An empty array removes all labels (optional)"`
+	AssigneeID   string    `json:"assignee_id,omitempty" jsonschema:"User ID to assign the task to (optional)"`
+	DeadlineDate string    `json:"deadline_date,omitempty" jsonschema:"New deadline date in YYYY-MM-DD format (optional)"`
 }
 
 type DeleteTaskInput struct {
@@ -238,17 +238,21 @@ func registerTaskTools(s *mcp.Server, c *todoist.Client) {
 		if input.Content != "" {
 			updateReq.Content = new(input.Content)
 		}
-		if input.Description != "" {
-			updateReq.Description = new(input.Description)
+		if input.Description != nil {
+			updateReq.Description = input.Description
 		}
-		if input.DueString != "" {
-			updateReq.DueString = new(input.DueString)
+		if input.DueString != nil {
+			due := *input.DueString
+			if due == "" {
+				due = "no date" // Todoist's native syntax for removing a due date
+			}
+			updateReq.DueString = new(due)
 		}
 		if input.Priority > 0 && input.Priority <= 4 {
 			updateReq.Priority = new(input.Priority)
 		}
-		if len(input.Labels) > 0 {
-			updateReq.Labels = new(input.Labels)
+		if input.Labels != nil {
+			updateReq.Labels = input.Labels
 		}
 		if input.AssigneeID != "" {
 			updateReq.AssigneeID = new(input.AssigneeID)

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -505,5 +506,110 @@ func TestMoveTaskTool(t *testing.T) {
 	text := resultText(result)
 	if !strings.Contains(text, "Successfully moved") {
 		t.Errorf("unexpected result: %s", text)
+	}
+}
+
+func captureUpdateBody(t *testing.T, rt *router, bodies *[]map[string]any) {
+	t.Helper()
+	rt.handle("POST", "/tasks/", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		*bodies = append(*bodies, body)
+		_, _ = w.Write([]byte(`{"id":"10","content":"Task"}`))
+	})
+}
+
+func TestUpdateTaskTool_ClearDescription(t *testing.T) {
+	rt := newRouter()
+	var bodies []map[string]any
+	captureUpdateBody(t, rt, &bodies)
+	cs, cleanup := setupTest(t, rt)
+	defer cleanup()
+
+	callTool(t, cs, "todoist_update_task", map[string]any{
+		"task_id":     "10",
+		"description": "",
+	})
+
+	if len(bodies) != 1 {
+		t.Fatalf("got %d update requests", len(bodies))
+	}
+	desc, ok := bodies[0]["description"]
+	if !ok {
+		t.Fatal("description key missing: empty string should clear, not be dropped")
+	}
+	if desc != "" {
+		t.Errorf("description = %v, want \"\"", desc)
+	}
+}
+
+func TestUpdateTaskTool_ClearDueDate(t *testing.T) {
+	for _, spelling := range []string{"", "no date"} {
+		rt := newRouter()
+		var bodies []map[string]any
+		captureUpdateBody(t, rt, &bodies)
+		cs, cleanup := setupTest(t, rt)
+
+		callTool(t, cs, "todoist_update_task", map[string]any{
+			"task_id":    "10",
+			"due_string": spelling,
+		})
+
+		if len(bodies) != 1 {
+			t.Fatalf("spelling %q: got %d update requests", spelling, len(bodies))
+		}
+		if got := bodies[0]["due_string"]; got != "no date" {
+			t.Errorf("spelling %q: due_string = %v, want \"no date\"", spelling, got)
+		}
+		cleanup()
+	}
+}
+
+func TestUpdateTaskTool_ClearLabels(t *testing.T) {
+	rt := newRouter()
+	var bodies []map[string]any
+	captureUpdateBody(t, rt, &bodies)
+	cs, cleanup := setupTest(t, rt)
+	defer cleanup()
+
+	callTool(t, cs, "todoist_update_task", map[string]any{
+		"task_id": "10",
+		"labels":  []string{},
+	})
+
+	if len(bodies) != 1 {
+		t.Fatalf("got %d update requests", len(bodies))
+	}
+	labels, ok := bodies[0]["labels"]
+	if !ok {
+		t.Fatal("labels key missing: empty array should clear, not be dropped")
+	}
+	arr, ok := labels.([]any)
+	if !ok || len(arr) != 0 {
+		t.Errorf("labels = %v, want []", labels)
+	}
+}
+
+func TestUpdateTaskTool_AbsentFieldsUntouched(t *testing.T) {
+	rt := newRouter()
+	var bodies []map[string]any
+	captureUpdateBody(t, rt, &bodies)
+	cs, cleanup := setupTest(t, rt)
+	defer cleanup()
+
+	callTool(t, cs, "todoist_update_task", map[string]any{
+		"task_id": "10",
+		"content": "Renamed",
+	})
+
+	if len(bodies) != 1 {
+		t.Fatalf("got %d update requests", len(bodies))
+	}
+	for _, key := range []string{"description", "due_string", "labels"} {
+		if _, ok := bodies[0][key]; ok {
+			t.Errorf("%s key present, want absent", key)
+		}
 	}
 }


### PR DESCRIPTION
Stage 4 of the tech debt refactor (spec: docs/superpowers/specs/2026-07-14-tech-debt-refactor-design.md). todoist_update_task now distinguishes absent from empty: an empty description clears it, an empty or 'no date' due_string removes the due date, and an empty labels array removes all labels. Absent fields behave exactly as before. Four new wire-level tests (TDD, RED to GREEN) cover each clearing path plus the absent-field regression case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015j22Jr9L3mzY3wNohfvWcu