### PR TITLE
feat: stage 5 retry and rate-limit handling

### DIFF
--- a/internal/todoist/client.go
+++ b/internal/todoist/client.go
@@ -1,22 +1,31 @@
 package todoist
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 )
 
 const defaultBaseURL = "https://api.todoist.com/api/v1"
 
+const maxAttempts = 3
+const maxRetryAfter = 30 * time.Second
+
+var defaultRetryBackoff = []time.Duration{250 * time.Millisecond, time.Second}
+
 // Client is an HTTP client for the Todoist API v1.
 type Client struct {
-	token      string
-	baseURL    string
-	httpClient *http.Client
+	token        string
+	baseURL      string
+	httpClient   *http.Client
+	retryBackoff []time.Duration // waits before attempts 2..n; tests may zero this
 }
 
 // PaginatedResponse wraps list endpoints in the Todoist API v1.
@@ -41,9 +50,10 @@ func WithBaseURL(url string) Option {
 // NewClient creates a new Todoist API client.
 func NewClient(token string, opts ...Option) *Client {
 	c := &Client{
-		token:      token,
-		baseURL:    defaultBaseURL,
-		httpClient: &http.Client{Timeout: 10 * time.Second},
+		token:        token,
+		baseURL:      defaultBaseURL,
+		httpClient:   &http.Client{Timeout: 10 * time.Second},
+		retryBackoff: defaultRetryBackoff,
 	}
 	for _, o := range opts {
 		o(c)
@@ -53,42 +63,106 @@ func NewClient(token string, opts ...Option) *Client {
 
 // do executes an HTTP request against the Todoist API and returns the
 // response body bytes. For responses with no content (204) it returns nil.
+// 429 and 5xx responses are retried up to maxAttempts times; a 429's
+// Retry-After header overrides the backoff schedule, capped at maxRetryAfter.
 func (c *Client) do(ctx context.Context, method, endpoint string, body any) ([]byte, error) {
-	var reqBody io.Reader
+	var bodyBytes []byte
 	if body != nil {
 		data, err := json.Marshal(body)
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal request body: %w", err)
 		}
-		reqBody = strings.NewReader(string(data))
+		bodyBytes = data
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+endpoint, reqBody)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+	var lastErr error
+	var wait time.Duration
+	for attempt := range maxAttempts {
+		if attempt > 0 {
+			if err := sleepCtx(ctx, wait); err != nil {
+				return nil, err
+			}
+		}
+
+		var reqBody io.Reader
+		if bodyBytes != nil {
+			reqBody = bytes.NewReader(bodyBytes)
+		}
+		req, err := http.NewRequestWithContext(ctx, method, c.baseURL+endpoint, reqBody)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request: %w", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+c.token)
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("failed to make request: %w", err)
+		}
+		respBody, err := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read response: %w", err)
+		}
+
+		switch {
+		case resp.StatusCode == http.StatusNoContent:
+			return nil, nil
+		case resp.StatusCode >= 200 && resp.StatusCode < 300:
+			return respBody, nil
+		case resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500:
+			lastErr = fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(respBody))
+			wait = c.backoffFor(attempt)
+			if resp.StatusCode == http.StatusTooManyRequests {
+				if d, ok := parseRetryAfter(resp.Header.Get("Retry-After")); ok {
+					wait = d
+				}
+			}
+			slog.Debug("retrying todoist request", "status", resp.StatusCode, "attempt", attempt+1, "wait", wait.String())
+		default:
+			return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(respBody))
+		}
 	}
+	return nil, lastErr
+}
 
-	req.Header.Set("Authorization", "Bearer "+c.token)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to make request: %w", err)
+// backoffFor returns the wait before the attempt following `attempt`
+// (0-indexed), reusing the last configured wait when out of range.
+func (c *Client) backoffFor(attempt int) time.Duration {
+	if len(c.retryBackoff) == 0 {
+		return 0
 	}
-	defer func() { _ = resp.Body.Close() }()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
+	if attempt < len(c.retryBackoff) {
+		return c.retryBackoff[attempt]
 	}
+	return c.retryBackoff[len(c.retryBackoff)-1]
+}
 
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(respBody))
+// parseRetryAfter parses a Retry-After header given in seconds. The
+// second return is false when the header is absent or unusable.
+func parseRetryAfter(h string) (time.Duration, bool) {
+	if h == "" {
+		return 0, false
 	}
-
-	if resp.StatusCode == http.StatusNoContent {
-		return nil, nil
+	secs, err := strconv.Atoi(strings.TrimSpace(h))
+	if err != nil || secs < 0 {
+		return 0, false
 	}
+	d := min(time.Duration(secs)*time.Second, maxRetryAfter)
+	return d, true
+}
 
-	return respBody, nil
+// sleepCtx waits for d or until ctx is done, whichever comes first.
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
 }

--- a/internal/todoist/client_test.go
+++ b/internal/todoist/client_test.go
@@ -2,9 +2,12 @@ package todoist
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 )
 
 func testServer(t *testing.T, handler http.HandlerFunc) (*Client, *httptest.Server) {
@@ -78,5 +81,105 @@ func TestDo_sendsJSONBody(t *testing.T) {
 	_, err := c.do(context.Background(), "POST", "/test", map[string]string{"key": "val"})
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestDoRetriesOn429(t *testing.T) {
+	var calls int
+	c, srv := testServer(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		_, _ = w.Write([]byte(`{"results":[],"next_cursor":""}`))
+	})
+	defer srv.Close()
+
+	if _, err := c.GetTasks(context.Background(), ""); err != nil {
+		t.Fatalf("expected success after retry, got %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("calls = %d, want 2", calls)
+	}
+}
+
+func TestDoFailsAfterMaxAttemptsOn500(t *testing.T) {
+	var calls int
+	c, srv := testServer(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	defer srv.Close()
+	c.retryBackoff = []time.Duration{0, 0}
+
+	_, err := c.GetTasks(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	if !strings.Contains(err.Error(), "status 500") {
+		t.Errorf("err = %v, want status 500 mention", err)
+	}
+	if calls != maxAttempts {
+		t.Errorf("calls = %d, want %d", calls, maxAttempts)
+	}
+}
+
+func TestDoNoRetryOn4xx(t *testing.T) {
+	var calls int
+	c, srv := testServer(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusBadRequest)
+	})
+	defer srv.Close()
+
+	if _, err := c.GetTasks(context.Background(), ""); err == nil {
+		t.Fatal("expected error")
+	}
+	if calls != 1 {
+		t.Errorf("calls = %d, want 1", calls)
+	}
+}
+
+func TestDoContextCanceledDuringBackoff(t *testing.T) {
+	var calls int
+	c, srv := testServer(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	defer srv.Close()
+	// default backoff (250ms) is longer than the deadline
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := c.GetTasks(ctx, "")
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("err = %v, want context.DeadlineExceeded", err)
+	}
+	if calls != 1 {
+		t.Errorf("calls = %d, want 1 (canceled during first backoff)", calls)
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	cases := []struct {
+		in   string
+		want time.Duration
+		ok   bool
+	}{
+		{"0", 0, true},
+		{"2", 2 * time.Second, true},
+		{"60", maxRetryAfter, true}, // capped at 30s
+		{"", 0, false},
+		{"garbage", 0, false},
+		{"-1", 0, false},
+	}
+	for _, tc := range cases {
+		got, ok := parseRetryAfter(tc.in)
+		if got != tc.want || ok != tc.ok {
+			t.Errorf("parseRetryAfter(%q) = (%v, %v), want (%v, %v)", tc.in, got, ok, tc.want, tc.ok)
+		}
 	}
 }

--- a/internal/todoist/tasks_test.go
+++ b/internal/todoist/tasks_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestGetTasks(t *testing.T) {
@@ -349,6 +350,7 @@ func TestGetTasksByFilter_apiErrorOnSecondPage(t *testing.T) {
 		}
 	})
 	defer srv.Close()
+	c.retryBackoff = []time.Duration{0, 0} // avoid slow test due to 500 retries
 
 	_, err := c.GetTasksByFilter(context.Background(), "today")
 	if err == nil {
@@ -592,6 +594,7 @@ func TestFindTaskByName_apiErrorOnSecondPage(t *testing.T) {
 		}
 	})
 	defer srv.Close()
+	c.retryBackoff = []time.Duration{0, 0} // avoid slow test due to 500 retries
 
 	_, err := c.FindTaskByName(context.Background(), "Target task")
 	if err == nil {


### PR DESCRIPTION
Stage 5 (final) of the tech debt refactor (spec: docs/superpowers/specs/2026-07-14-tech-debt-refactor-design.md). client.do now retries 429 (honoring Retry-After in seconds, capped at 30s) and 5xx responses up to 3 attempts with a 250ms/1s backoff schedule, aborting promptly on context cancellation. Other 4xx statuses still fail immediately. Five new tests (TDD, RED to GREEN) cover retry-then-success, exhaustion, no-retry-on-4xx, cancellation during backoff, and Retry-After parsing/capping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015j22Jr9L3mzY3wNohfvWcu