### PR TITLE
feat: idempotent POST retries via X-Request-Id

### DIFF
--- a/internal/todoist/client.go
+++ b/internal/todoist/client.go
@@ -3,6 +3,7 @@ package todoist
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -75,6 +76,13 @@ func (c *Client) do(ctx context.Context, method, endpoint string, body any) ([]b
 		bodyBytes = data
 	}
 
+	// One idempotency key per logical request, reused across retry
+	// attempts, so a retried POST cannot create a duplicate resource.
+	var requestID string
+	if method == http.MethodPost {
+		requestID = newRequestID()
+	}
+
 	var lastErr error
 	var wait time.Duration
 	for attempt := range maxAttempts {
@@ -94,6 +102,9 @@ func (c *Client) do(ctx context.Context, method, endpoint string, body any) ([]b
 		}
 		req.Header.Set("Authorization", "Bearer "+c.token)
 		req.Header.Set("Content-Type", "application/json")
+		if requestID != "" {
+			req.Header.Set("X-Request-Id", requestID)
+		}
 
 		resp, err := c.httpClient.Do(req)
 		if err != nil {
@@ -118,7 +129,9 @@ func (c *Client) do(ctx context.Context, method, endpoint string, body any) ([]b
 					wait = d
 				}
 			}
-			slog.Debug("retrying todoist request", "status", resp.StatusCode, "attempt", attempt+1, "wait", wait.String())
+			if attempt < maxAttempts-1 {
+				slog.Debug("retrying todoist request", "status", resp.StatusCode, "attempt", attempt+1, "wait", wait)
+			}
 		default:
 			return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(respBody))
 		}
@@ -150,6 +163,19 @@ func parseRetryAfter(h string) (time.Duration, bool) {
 	}
 	d := min(time.Duration(secs)*time.Second, maxRetryAfter)
 	return d, true
+}
+
+// newRequestID returns a random UUID version 4 string for the
+// X-Request-Id idempotency header. crypto/rand.Read is documented to
+// never fail, but if it somehow does the header is simply omitted.
+func newRequestID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return ""
+	}
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
 }
 
 // sleepCtx waits for d or until ctx is done, whichever comes first.

--- a/internal/todoist/client_test.go
+++ b/internal/todoist/client_test.go
@@ -163,6 +163,73 @@ func TestDoContextCanceledDuringBackoff(t *testing.T) {
 	}
 }
 
+func TestDoSendsRequestIDOnPost(t *testing.T) {
+	var reqID string
+	c, srv := testServer(t, func(w http.ResponseWriter, r *http.Request) {
+		reqID = r.Header.Get("X-Request-Id")
+		_, _ = w.Write([]byte(`{}`))
+	})
+	defer srv.Close()
+
+	if _, err := c.do(context.Background(), "POST", "/test", map[string]string{"key": "val"}); err != nil {
+		t.Fatal(err)
+	}
+	if reqID == "" {
+		t.Fatal("X-Request-Id header missing on POST")
+	}
+	if len(reqID) != 36 || strings.Count(reqID, "-") != 4 {
+		t.Errorf("X-Request-Id = %q, want UUID format", reqID)
+	}
+}
+
+func TestDoRequestIDStableAcrossRetries(t *testing.T) {
+	var ids []string
+	c, srv := testServer(t, func(w http.ResponseWriter, r *http.Request) {
+		ids = append(ids, r.Header.Get("X-Request-Id"))
+		if len(ids) == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		_, _ = w.Write([]byte(`{}`))
+	})
+	defer srv.Close()
+	c.retryBackoff = []time.Duration{0, 0}
+
+	if _, err := c.do(context.Background(), "POST", "/test", map[string]string{"key": "val"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(ids) != 2 {
+		t.Fatalf("calls = %d, want 2", len(ids))
+	}
+	if ids[0] == "" {
+		t.Fatal("X-Request-Id header missing on first attempt")
+	}
+	if ids[0] != ids[1] {
+		t.Errorf("X-Request-Id changed across retries: %q then %q, want identical", ids[0], ids[1])
+	}
+}
+
+func TestDoNoRequestIDOnGet(t *testing.T) {
+	var reqID string
+	got := false
+	c, srv := testServer(t, func(w http.ResponseWriter, r *http.Request) {
+		reqID = r.Header.Get("X-Request-Id")
+		got = true
+		_, _ = w.Write([]byte(`{}`))
+	})
+	defer srv.Close()
+
+	if _, err := c.do(context.Background(), "GET", "/test", nil); err != nil {
+		t.Fatal(err)
+	}
+	if !got {
+		t.Fatal("request never reached server")
+	}
+	if reqID != "" {
+		t.Errorf("X-Request-Id = %q on GET, want empty (idempotency header is POST-only)", reqID)
+	}
+}
+
 func TestParseRetryAfter(t *testing.T) {
 	cases := []struct {
 		in   string


### PR DESCRIPTION
Follow-up to the five-stage tech debt refactor, addressing the final review's one Important finding: 5xx retries applied to non-idempotent POSTs, so a 500 returned after Todoist commits a create could produce a duplicate task.

client.do now generates one random UUID v4 per logical POST and sends it as X-Request-Id on every retry attempt, letting Todoist deduplicate. GET and DELETE stay unkeyed (naturally idempotent). Also folds in two review nits: the retry debug log no longer fires on the final attempt, and the wait duration is passed to slog directly.

TDD: three new tests (header present and UUID-shaped on POST, stable across a 500-then-200 retry, absent on GET) written first and watched fail.

Note: attempted via gh stack per request, but Stacked PRs are not enabled for this repository (private preview), so this is a regular single PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015j22Jr9L3mzY3wNohfvWcu